### PR TITLE
fix missing 'var' in GoogleChartLoader.js

### DIFF
--- a/src/components/GoogleChartLoader.js
+++ b/src/components/GoogleChartLoader.js
@@ -18,7 +18,7 @@ var GoogleChartLoader = function(){
 		}
 
 		this.is_loading = true;
-		self = this;
+		var self = this;
 
 	 	var options = {
 	    	dataType: "script",


### PR DESCRIPTION
As of v0.1.4, this loader overwrites `window.self`, breaking other code that uses `window.self`.