### PR TITLE
Allow for props to load in specific versions and packages

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -21,7 +21,7 @@ var Chart = React.createClass({
 	componentDidMount: function(){
 	    var self = this;
 
-	    GoogleChartLoader.init().then(function(){
+	    GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function(){
 	      self.drawChart();
 	    });     
 	},

--- a/src/components/GoogleChartLoader.js
+++ b/src/components/GoogleChartLoader.js
@@ -11,7 +11,8 @@ var GoogleChartLoader = function(){
 	this.google_promise = q.defer();
 	this.url = "https://www.google.com/jsapi";
 	this.packages = ["corechart"];
-	this.init = function() {
+	this.version = "1";
+	this.init = function(packages, version) {
 
 		if (this.is_loading) {
 			return this.google_promise.promise;
@@ -27,8 +28,8 @@ var GoogleChartLoader = function(){
 	  	};
 	  	$.ajax(options).done(
 	  		function(){
-	    		google.load("visualization", "1", {
-	      			packages:self.packages,
+	    		google.load("visualization", version || self.version, {
+	      			packages: packages || self.packages,
 	      			callback: function() {
 	      				self.is_loaded = true;
 	        			self.google_promise.resolve();


### PR DESCRIPTION
Allow proptypes to dictate which pickages and version the google visualization will load. Which allows you to load beta packages. (gantt in my case)