### PR TITLE
Add/action

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -4,273 +4,261 @@ var DEFAULT_COLORS = require('../constants/DEFAULT_CHART_COLORS');
 
 var uniqueId = 0;
 var generateUniqueId = function() {
-  uniqueId++;
-  return "reactgooglegraph" + uniqueId;
+    uniqueId++;
+    return "reactgooglegraph" + uniqueId;
 };
 
 var Chart = React.createClass({
-  chart: null,
-  wrapper: null,
-  hidden_columns: [],
-  data_table: [],
+	chart: null,
+	wrapper: null,
+	hidden_columns: [],
+	data_table: [],
+	getInitialState: function() {
+		return {
+            graph_id: this.props.graph_id || generateUniqueId()
+		};
+	},
+	componentDidMount: function(){
+	    var self = this;
 
-  getInitialState: function() {
-    return {
-      graph_id: this.props.graph_id || generateUniqueId()
-    };
-  },
+	    GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function(){
+	      self.drawChart();
+	    });
+	},
 
-  componentDidMount: function(){
-    var self = this;
+	componentDidUpdate: function(){
+		if (GoogleChartLoader.is_loaded){
+			this.drawChart();
+		};
+  	},
 
-    GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function(){
-      self.drawChart();
-    });
-  },
+	getDefaultProps: function() {
+		return {
+			chartType : 'LineChart',
+			rows: [],
+			columns: [],
+			options: {
+				chart: {
+					title: 'Chart Title',
+					subtitle: 'Subtitle'
+				},
+				hAxis: {title: 'X Label'},
+				vAxis: {title: 'Y Label'},
+				width: '400px',
+				height: '300px'
 
-  componentDidUpdate: function(){
-    if (GoogleChartLoader.is_loaded){
-      this.drawChart();
-    };
-  },
+	      	},
+	      	chartEvents : [],
+	      	data: null,
+	      	onSelect: null,
+	        legend_toggle: false
+	    };
+	},
 
-  getDefaultProps: function() {
-    return {
-      chartType : 'LineChart',
-      rows: [],
-      columns: [],
-      options: {
-        chart: {
-          title: 'Chart Title',
-          subtitle: 'Subtitle'
-        },
-        hAxis: {title: 'X Label'},
-        vAxis: {title: 'Y Label'},
-        width: '400px',
-        height: '300px'
-      },
-      chartEvents : [],
-      data: null,
-      onSelect: null,
-      legend_toggle: false
-    };
-  },
 
-  render: function() {
-    return React.DOM.div({
-      id: this.state.graph_id,
-      style: {
-        height: this.props.height,
-        width:this.props.width
-      }
-    });
-  },
 
-  build_data_table : function() {
-    var data_table = new google.visualization.DataTable();
-    for (var i = 0 ; i < this.props.columns.length; i++) {
-      data_table.addColumn(this.props.columns[i].type, this.props.columns[i].label);
-    }
+	render: function() {
+		return React.DOM.div({id: this.state.graph_id, style: {height: this.props.height, width:this.props.width}});
+	},
+	build_data_table : function() {
 
-    if (this.props.rows.length > 0) {
-      data_table.addRows(this.props.rows);
-    }
-    return data_table;
-  },
+		var data_table = new google.visualization.DataTable();
+		for (var i = 0 ; i < this.props.columns.length; i++) {
+			data_table.addColumn(this.props.columns[i].type, this.props.columns[i].label);
+		}
 
-  drawChart: function() {
+		if (this.props.rows.length > 0) {
+			data_table.addRows(this.props.rows);
+		}
+		return data_table;
+	},
 
-    if (this.props.data !== null ) {
-      if (this.props.data.length === 0 ) {
-        // Initialized. Do nothing and wait for data
-        return;
-      }
+	drawChart: function() {
 
-      this.data_table = this.props.data;
-    }
-    else if (this.props.columns.length === 0) {
-      return;
-    }
-    else {
-      this.data_table = this.build_data_table();
-    }
+		if (this.props.data !== null ) {
+			if (this.props.data.length === 0 ) {
+				// Initialized. Do nothing and wait for data
+				return;
+			}
 
-    // creates the google wrapper
-    this.wrapper = new google.visualization.ChartWrapper({
-      chartType: this.props.chartType,
-      dataTable: this.data_table,
-      options : this.props.options,
-      containerId: this.state.graph_id
-    });
+			this.data_table = this.props.data;
+		}
+		else if (this.props.columns.length === 0) {
+			return;
+		}
+		else {
+			this.data_table = this.build_data_table();
+		}
 
-    this.data_table = this.wrapper.getDataTable();
 
-    var self = this;
-    google.visualization.events.addOneTimeListener(
-      this.wrapper,
-      'ready',
-      function() {
-        // when the wrapper is ready, define the chart
-        self.chart = self.wrapper.getChart();
-        // add the chart events
-        self.listen_to_chart_events.call(this);
-      }
-    );
+		this.wrapper = new google.visualization.ChartWrapper({
+			chartType: this.props.chartType,
+			dataTable: this.data_table,
+			options : this.props.options,
+			containerId: this.state.graph_id
+		});
 
-    if (this.props.legend_toggle) {
-      google.visualization.events.addListener(
-        this.wrapper,
-        'select',
-        function() { self.default_chart_select.call(this); }
-      );
-    }
+		this.data_table = this.wrapper.getDataTable();
 
-    if (this.props.onSelect !== null) {
-      google.visualization.events.addListener(
-        this.wrapper,
-        'select',
-        function() { self.props.onSelect(self, self.chart.getSelection()); }
-      );
-    }
+        var self = this;
 
-    self.wrapper.draw();
-  },
-  listen_to_chart_events: function() {
-    var self = this;
-    var event_data;
-    for (var i = 0; i < this.props.chartEvents.length; i++) {
-      if (this.props.chartEvents[i].eventName === 'ready') {
-        this.props.chartEvents[i].callback(this);
-      }
-      else if (this.props.chartEvents[i].eventName === 'action') {
-        // if any action was specified, add it to the chart
-        var action_parameters = this.props.chartEvents[i].callback;
-        self.chart.setAction({
-          id: action_parameters.id,
-          text: action_parameters.text,
-          // bind the chart back to the action callback so we can get the chart information
-          action: action_parameters.action.bind(self.chart),
+        google.visualization.events.addOneTimeListener(this.wrapper, 'ready', function() {
+        	self.chart = self.wrapper.getChart();
+        	self.listen_to_chart_events.call(this);
         });
-      }
-      else {
-        (function(callback){
-          google
-            .visualization
-            .events
-            .addListener(self.chart, self.props.chartEvents[i].eventName, function (e){
-              callback(self, e);
-            });
-        })(self.props.chartEvents[i].callback)
-      }
+
+        if (this.props.legend_toggle) {
+        	google.visualization.events.addListener(this.wrapper, 'select', function() { self.default_chart_select.call(this); });
+        }
+        if (this.props.onSelect !== null) {
+        	google.visualization.events.addListener(this.wrapper, 'select', function() { self.props.onSelect(self, self.chart.getSelection()); });
+        }
+        self.wrapper.draw();
+
+    },
+    listen_to_chart_events: function() {
+
+    	var self = this;
+    	var event_data;
+  		for (var i = 0; i < this.props.chartEvents.length; i++) {
+  			if (this.props.chartEvents[i].eventName === 'ready') {
+  				this.props.chartEvents[i].callback(this);
+  			}
+        else if (this.props.chartEvents[i].eventName === 'action') {
+          // if any action was specified, add it to the chart
+          var action_parameters = this.props.chartEvents[i].callback;
+          self.chart.setAction({
+            id: action_parameters.id,
+            text: action_parameters.text,
+            // bind the chart back to the action callback so we can get the chart information
+            action: action_parameters.action.bind(self.chart),
+          });
+        }
+  			else {
+          (function(callback){
+            google
+              .visualization
+              .events
+              .addListener(self.chart, self.props.chartEvents[i].eventName, function (e){
+                callback(self, e);
+              });
+          })(self.props.chartEvents[i].callback)
+  			}
+
+		}
+
+
+    },
+
+    default_chart_select: function() {
+		var selection = this.chart.getSelection();
+	    // if selection length is 0, we deselected an element
+	    if (selection.length > 0) {
+	        // if row is undefined, we clicked on the legend
+	        if (selection[0].row == null) {
+	        	var column = selection[0].column;
+	        	this.toggle_points(column);
+	        }
+	    }
+    },
+
+    build_empty_column: function(index) {
+
+    	return {
+			label: this.data_table.getColumnLabel(index),
+            type: this.data_table.getColumnType(index),
+            calc: function () {
+                return null;
+            }
+		};
+    },
+
+    build_column_from_src: function(index) {
+    	return {
+			label: this.data_table.getColumnLabel(index),
+			type: this.data_table.getColumnType(index),
+			sourceColumn: index
+		};
+    },
+
+    toggle_points: function(column) {
+
+		//Need to show legend !!
+
+    	var view = new google.visualization.DataView(this.wrapper.getDataTable());
+    	var column_count = view.getNumberOfColumns();
+    	var colors = [],
+    		columns = [],
+			empty_columns = [],
+			column_hidden,
+			empty_column,
+			column_from_src;
+
+		for (var i = 0; i < column_count; i++) {
+
+			// If user clicked on legend
+			if (i === column ) {
+
+				column_hidden = (typeof this.hidden_columns[i] !== 'undefined');
+
+				//User wants to hide values
+				if (!column_hidden ) {
+					// Null out the values of the column
+					empty_column =  this.build_empty_column(i);
+					columns.push(empty_column);
+
+					this.hidden_columns[i] = { color : this.get_column_color(i-1) };
+					colors.push('#CCCCCC');
+				}
+				//User wants to show values
+				else {
+					column_from_src = this.build_column_from_src(i);
+    				columns.push(column_from_src);
+
+    				var previous_color = this.hidden_columns[i].color;
+    				delete this.hidden_columns[i];
+    				colors.push(previous_color);
+				}
+			}
+			else if (typeof this.hidden_columns[i] !== 'undefined') {
+				empty_column =  this.build_empty_column(i);
+				columns.push(empty_column);
+				colors.push('#CCCCCC');
+			}
+			else {
+				column_from_src = this.build_column_from_src(i);
+    			columns.push(column_from_src);
+
+					if (i !== 0) {
+						colors.push(this.get_column_color(i-1));
+					}
+			}
+		}
+
+		view.setColumns(columns);
+    	this.props.options.colors = colors;
+
+    	this.chart.draw(view, this.props.options);
+    },
+
+
+    get_column_color: function(column_index) {
+    	if (this.props.options.colors) {
+			if (this.props.options.colors[column_index]) {
+				return this.props.options.colors[column_index];
+			}
+		}
+		else {
+			if (typeof DEFAULT_COLORS[column_index] !== 'undefined') {
+				return DEFAULT_COLORS[column_index];
+			}
+			else {
+				return DEFAULT_COLORS[0];
+			}
+
+		}
     }
-  },
 
-  default_chart_select: function() {
-  var selection = this.chart.getSelection();
-    // if selection length is 0, we deselected an element
-    if (selection.length > 0) {
-      // if row is undefined, we clicked on the legend
-      if (selection[0].row == null) {
-        var column = selection[0].column;
-        this.toggle_points(column);
-      }
-    }
-  },
-
-  build_empty_column: function(index) {
-
-    return {
-      label: this.data_table.getColumnLabel(index),
-      type: this.data_table.getColumnType(index),
-      calc: function () {
-          return null;
-      }
-    };
-  },
-
-  build_column_from_src: function(index) {
-    return {
-      label: this.data_table.getColumnLabel(index),
-      type: this.data_table.getColumnType(index),
-      sourceColumn: index
-    };
-  },
-
-  toggle_points: function(column) {
-
-  //Need to show legend !!
-
-  var view = new google.visualization.DataView(this.wrapper.getDataTable());
-  var column_count = view.getNumberOfColumns();
-  var colors = [],
-    columns = [],
-    empty_columns = [],
-    column_hidden,
-    empty_column,
-    column_from_src;
-
-  for (var i = 0; i < column_count; i++) {
-
-    // If user clicked on legend
-    if (i === column ) {
-
-      column_hidden = (typeof this.hidden_columns[i] !== 'undefined');
-
-      //User wants to hide values
-      if (!column_hidden ) {
-        // Null out the values of the column
-        empty_column =  this.build_empty_column(i);
-        columns.push(empty_column);
-
-        this.hidden_columns[i] = { color : this.get_column_color(i-1) };
-        colors.push('#CCCCCC');
-      }
-      //User wants to show values
-      else {
-        column_from_src = this.build_column_from_src(i);
-        columns.push(column_from_src);
-
-        var previous_color = this.hidden_columns[i].color;
-        delete this.hidden_columns[i];
-        colors.push(previous_color);
-      }
-    }
-    else if (typeof this.hidden_columns[i] !== 'undefined') {
-      empty_column =  this.build_empty_column(i);
-      columns.push(empty_column);
-      colors.push('#CCCCCC');
-    }
-    else {
-      column_from_src = this.build_column_from_src(i);
-      columns.push(column_from_src);
-
-      if (i !== 0) {
-        colors.push(this.get_column_color(i-1));
-      }
-    }
-  }
-
-  view.setColumns(columns);
-    this.props.options.colors = colors;
-
-    this.chart.draw(view, this.props.options);
-  },
-
-  get_column_color: function(column_index) {
-    if (this.props.options.colors) {
-      if (this.props.options.colors[column_index]) {
-        return this.props.options.colors[column_index];
-      }
-    }
-    else {
-      if (typeof DEFAULT_COLORS[column_index] !== 'undefined') {
-        return DEFAULT_COLORS[column_index];
-      }
-      else {
-        return DEFAULT_COLORS[0];
-      }
-    }
-  }
 });
 
 module.exports = Chart;

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -49,6 +49,7 @@ var Chart = React.createClass({
 
 	      	},
 	      	chartEvents : [],
+	      	chartActions : null,
 	      	data: null,
 	      	onSelect: null,
 	        legend_toggle: false
@@ -105,6 +106,7 @@ var Chart = React.createClass({
         google.visualization.events.addOneTimeListener(this.wrapper, 'ready', function() {
         	self.chart = self.wrapper.getChart();
         	self.listen_to_chart_events.call(this);
+        	self.add_chart_actions.call(this);
         });
 
         if (this.props.legend_toggle) {
@@ -124,16 +126,6 @@ var Chart = React.createClass({
   			if (this.props.chartEvents[i].eventName === 'ready') {
   				this.props.chartEvents[i].callback(this);
   			}
-        else if (this.props.chartEvents[i].eventName === 'action') {
-          // if any action was specified, add it to the chart
-          var action_parameters = this.props.chartEvents[i].callback;
-          self.chart.setAction({
-            id: action_parameters.id,
-            text: action_parameters.text,
-            // bind the chart back to the action callback so we can get the chart information
-            action: action_parameters.action.bind(self.chart),
-          });
-        }
   			else {
           (function(callback){
             google
@@ -144,12 +136,20 @@ var Chart = React.createClass({
               });
           })(self.props.chartEvents[i].callback)
   			}
-
-		}
-
-
+		  }
     },
-
+    add_chart_actions: function () {
+    	var self = this;
+      // if any action was specified, add it to the chart
+      if (this.props.chartActions != null) {
+        self.chart.setAction({
+          id: this.props.chartActions.id,
+          text: this.props.chartActions.text,
+          // bind the chart back to the action callback so we can get the chart information
+          action: this.props.chartActions.action.bind(self.chart)
+        });
+      };
+    },
     default_chart_select: function() {
 		var selection = this.chart.getSelection();
 	    // if selection length is 0, we deselected an element

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -4,251 +4,269 @@ var DEFAULT_COLORS = require('../constants/DEFAULT_CHART_COLORS');
 
 var uniqueId = 0;
 var generateUniqueId = function() {
-    uniqueId++;
-    return "reactgooglegraph" + uniqueId;
+  uniqueId++;
+  return "reactgooglegraph" + uniqueId;
 };
 
 var Chart = React.createClass({
-	chart: null,
-	wrapper: null,
-	hidden_columns: [],
-	data_table: [],
-	getInitialState: function() {
-		return {
-            graph_id: this.props.graph_id || generateUniqueId()
-		};
-	},
-	componentDidMount: function(){
-	    var self = this;
+  chart: null,
+  wrapper: null,
+  hidden_columns: [],
+  data_table: [],
 
-	    GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function(){
-	      self.drawChart();
-	    });
-	},
+  getInitialState: function() {
+    return {
+      graph_id: this.props.graph_id || generateUniqueId()
+    };
+  },
 
-	componentDidUpdate: function(){
-		if (GoogleChartLoader.is_loaded){
-			this.drawChart();
-		};
-  	},
+  componentDidMount: function(){
+    var self = this;
 
-	getDefaultProps: function() {
-		return {
-			chartType : 'LineChart',
-			rows: [],
-			columns: [],
-			options: {
-				chart: {
-					title: 'Chart Title',
-					subtitle: 'Subtitle'
-				},
-				hAxis: {title: 'X Label'},
-				vAxis: {title: 'Y Label'},
-				width: '400px',
-				height: '300px'
+    GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function(){
+      self.drawChart();
+    });
+  },
 
-	      	},
-	      	chartEvents : [],
-	      	data: null,
-	      	onSelect: null,
-	        legend_toggle: false
-	    };
-	},
+  componentDidUpdate: function(){
+    if (GoogleChartLoader.is_loaded){
+      this.drawChart();
+    };
+  },
 
+  getDefaultProps: function() {
+    return {
+      chartType : 'LineChart',
+      rows: [],
+      columns: [],
+      options: {
+        chart: {
+          title: 'Chart Title',
+          subtitle: 'Subtitle'
+        },
+        hAxis: {title: 'X Label'},
+        vAxis: {title: 'Y Label'},
+        width: '400px',
+        height: '300px'
+      },
+      chartEvents : [],
+      chartAction: null,
+      data: null,
+      onSelect: null,
+      legend_toggle: false
+    };
+  },
 
+  render: function() {
+    return React.DOM.div({
+      id: this.state.graph_id,
+      style: {
+        height: this.props.height,
+        width:this.props.width
+      }
+    });
+  },
 
-	render: function() {
-		return React.DOM.div({id: this.state.graph_id, style: {height: this.props.height, width:this.props.width}});
-	},
-	build_data_table : function() {
-
-		var data_table = new google.visualization.DataTable();
-		for (var i = 0 ; i < this.props.columns.length; i++) {
-			data_table.addColumn(this.props.columns[i].type, this.props.columns[i].label);
-		}
-
-		if (this.props.rows.length > 0) {
-			data_table.addRows(this.props.rows);
-		}
-		return data_table;
-	},
-
-	drawChart: function() {
-
-		if (this.props.data !== null ) {
-			if (this.props.data.length === 0 ) {
-				// Initialized. Do nothing and wait for data
-				return;
-			}
-
-			this.data_table = this.props.data;
-		}
-		else if (this.props.columns.length === 0) {
-			return;
-		}
-		else {
-			this.data_table = this.build_data_table();
-		}
-
-
-		this.wrapper = new google.visualization.ChartWrapper({
-			chartType: this.props.chartType,
-			dataTable: this.data_table,
-			options : this.props.options,
-			containerId: this.state.graph_id
-		});
-
-		this.data_table = this.wrapper.getDataTable();
-
-        var self = this;
-
-        google.visualization.events.addOneTimeListener(this.wrapper, 'ready', function() {
-        	self.chart = self.wrapper.getChart();
-        	self.listen_to_chart_events.call(this);
-        });
-
-        if (this.props.legend_toggle) {
-        	google.visualization.events.addListener(this.wrapper, 'select', function() { self.default_chart_select.call(this); });
-        }
-        if (this.props.onSelect !== null) {
-        	google.visualization.events.addListener(this.wrapper, 'select', function() { self.props.onSelect(self, self.chart.getSelection()); });
-        }
-        self.wrapper.draw();
-
-    },
-    listen_to_chart_events: function() {
-
-    	var self = this;
-    	var event_data;
-  		for (var i = 0; i < this.props.chartEvents.length; i++) {
-  			if (this.props.chartEvents[i].eventName === 'ready') {
-  				this.props.chartEvents[i].callback(this);
-  			}
-  			else {
-          (function(callback){
-            google
-              .visualization
-              .events
-              .addListener(self.chart, self.props.chartEvents[i].eventName, function (e){
-                callback(self, e);
-              });
-          })(self.props.chartEvents[i].callback)
-  			}
-
-		}
-
-
-    },
-
-    default_chart_select: function() {
-		var selection = this.chart.getSelection();
-	    // if selection length is 0, we deselected an element
-	    if (selection.length > 0) {
-	        // if row is undefined, we clicked on the legend
-	        if (selection[0].row == null) {
-	        	var column = selection[0].column;
-	        	this.toggle_points(column);
-	        }
-	    }
-    },
-
-    build_empty_column: function(index) {
-
-    	return {
-			label: this.data_table.getColumnLabel(index),
-            type: this.data_table.getColumnType(index),
-            calc: function () {
-                return null;
-            }
-		};
-    },
-
-    build_column_from_src: function(index) {
-    	return {
-			label: this.data_table.getColumnLabel(index),
-			type: this.data_table.getColumnType(index),
-			sourceColumn: index
-		};
-    },
-
-    toggle_points: function(column) {
-
-		//Need to show legend !!
-
-    	var view = new google.visualization.DataView(this.wrapper.getDataTable());
-    	var column_count = view.getNumberOfColumns();
-    	var colors = [],
-    		columns = [],
-			empty_columns = [],
-			column_hidden,
-			empty_column,
-			column_from_src;
-
-		for (var i = 0; i < column_count; i++) {
-
-			// If user clicked on legend
-			if (i === column ) {
-
-				column_hidden = (typeof this.hidden_columns[i] !== 'undefined');
-
-				//User wants to hide values
-				if (!column_hidden ) {
-					// Null out the values of the column
-					empty_column =  this.build_empty_column(i);
-					columns.push(empty_column);
-
-					this.hidden_columns[i] = { color : this.get_column_color(i-1) };
-					colors.push('#CCCCCC');
-				}
-				//User wants to show values
-				else {
-					column_from_src = this.build_column_from_src(i);
-    				columns.push(column_from_src);
-
-    				var previous_color = this.hidden_columns[i].color;
-    				delete this.hidden_columns[i];
-    				colors.push(previous_color);
-				}
-			}
-			else if (typeof this.hidden_columns[i] !== 'undefined') {
-				empty_column =  this.build_empty_column(i);
-				columns.push(empty_column);
-				colors.push('#CCCCCC');
-			}
-			else {
-				column_from_src = this.build_column_from_src(i);
-    			columns.push(column_from_src);
-
-					if (i !== 0) {
-						colors.push(this.get_column_color(i-1));
-					}
-			}
-		}
-
-		view.setColumns(columns);
-    	this.props.options.colors = colors;
-
-    	this.chart.draw(view, this.props.options);
-    },
-
-
-    get_column_color: function(column_index) {
-    	if (this.props.options.colors) {
-			if (this.props.options.colors[column_index]) {
-				return this.props.options.colors[column_index];
-			}
-		}
-		else {
-			if (typeof DEFAULT_COLORS[column_index] !== 'undefined') {
-				return DEFAULT_COLORS[column_index];
-			}
-			else {
-				return DEFAULT_COLORS[0];
-			}
-
-		}
+  build_data_table : function() {
+    var data_table = new google.visualization.DataTable();
+    for (var i = 0 ; i < this.props.columns.length; i++) {
+      data_table.addColumn(this.props.columns[i].type, this.props.columns[i].label);
     }
 
+    if (this.props.rows.length > 0) {
+      data_table.addRows(this.props.rows);
+    }
+    return data_table;
+  },
+
+  drawChart: function() {
+
+    if (this.props.data !== null ) {
+      if (this.props.data.length === 0 ) {
+        // Initialized. Do nothing and wait for data
+        return;
+      }
+
+      this.data_table = this.props.data;
+    }
+    else if (this.props.columns.length === 0) {
+      return;
+    }
+    else {
+      this.data_table = this.build_data_table();
+    }
+
+    this.wrapper = new google.visualization.ChartWrapper({
+      chartType: this.props.chartType,
+      dataTable: this.data_table,
+      options : this.props.options,
+      containerId: this.state.graph_id
+    });
+
+    this.data_table = this.wrapper.getDataTable();
+
+    var self = this;
+
+    google.visualization.events.addOneTimeListener(
+      this.wrapper,
+      'ready',
+      function() {
+        self.chart = self.wrapper.getChart();
+        self.listen_to_chart_events.call(this);
+      }
+    );
+
+    if (this.props.legend_toggle) {
+      google.visualization.events.addListener(
+        this.wrapper,
+        'select',
+        function() { self.default_chart_select.call(this); }
+      );
+    }
+
+    if (this.props.onSelect !== null) {
+      google.visualization.events.addListener(
+        this.wrapper,
+        'select',
+        function() { self.props.onSelect(self, self.chart.getSelection()); }
+      );
+    }
+
+    if (this.props.chartAction){
+      var action_parameters = this.props.action;
+      // pass the chart wrapper back to the action callback
+      action_parameters.action = action_parameters.action.callback(this)
+      this.wrapper.setAction(action_parameters);
+    }
+
+    self.wrapper.draw();
+  },
+  listen_to_chart_events: function() {
+    var self = this;
+    var event_data;
+    for (var i = 0; i < this.props.chartEvents.length; i++) {
+      if (this.props.chartEvents[i].eventName === 'ready') {
+        this.props.chartEvents[i].callback(this);
+      }
+      else {
+        (function(callback){
+          google
+            .visualization
+            .events
+            .addListener(self.chart, self.props.chartEvents[i].eventName, function (e){
+              callback(self, e);
+            });
+        })(self.props.chartEvents[i].callback)
+      }
+    }
+  },
+
+  default_chart_select: function() {
+  var selection = this.chart.getSelection();
+    // if selection length is 0, we deselected an element
+    if (selection.length > 0) {
+      // if row is undefined, we clicked on the legend
+      if (selection[0].row == null) {
+        var column = selection[0].column;
+        this.toggle_points(column);
+      }
+    }
+  },
+
+  build_empty_column: function(index) {
+
+    return {
+      label: this.data_table.getColumnLabel(index),
+      type: this.data_table.getColumnType(index),
+      calc: function () {
+          return null;
+      }
+    };
+  },
+
+  build_column_from_src: function(index) {
+    return {
+      label: this.data_table.getColumnLabel(index),
+      type: this.data_table.getColumnType(index),
+      sourceColumn: index
+    };
+  },
+
+  toggle_points: function(column) {
+
+  //Need to show legend !!
+
+  var view = new google.visualization.DataView(this.wrapper.getDataTable());
+  var column_count = view.getNumberOfColumns();
+  var colors = [],
+    columns = [],
+    empty_columns = [],
+    column_hidden,
+    empty_column,
+    column_from_src;
+
+  for (var i = 0; i < column_count; i++) {
+
+    // If user clicked on legend
+    if (i === column ) {
+
+      column_hidden = (typeof this.hidden_columns[i] !== 'undefined');
+
+      //User wants to hide values
+      if (!column_hidden ) {
+        // Null out the values of the column
+        empty_column =  this.build_empty_column(i);
+        columns.push(empty_column);
+
+        this.hidden_columns[i] = { color : this.get_column_color(i-1) };
+        colors.push('#CCCCCC');
+      }
+      //User wants to show values
+      else {
+        column_from_src = this.build_column_from_src(i);
+        columns.push(column_from_src);
+
+        var previous_color = this.hidden_columns[i].color;
+        delete this.hidden_columns[i];
+        colors.push(previous_color);
+      }
+    }
+    else if (typeof this.hidden_columns[i] !== 'undefined') {
+      empty_column =  this.build_empty_column(i);
+      columns.push(empty_column);
+      colors.push('#CCCCCC');
+    }
+    else {
+      column_from_src = this.build_column_from_src(i);
+      columns.push(column_from_src);
+
+      if (i !== 0) {
+        colors.push(this.get_column_color(i-1));
+      }
+    }
+  }
+
+  view.setColumns(columns);
+    this.props.options.colors = colors;
+
+    this.chart.draw(view, this.props.options);
+  },
+
+  get_column_color: function(column_index) {
+    if (this.props.options.colors) {
+      if (this.props.options.colors[column_index]) {
+        return this.props.options.colors[column_index];
+      }
+    }
+    else {
+      if (typeof DEFAULT_COLORS[column_index] !== 'undefined') {
+        return DEFAULT_COLORS[column_index];
+      }
+      else {
+        return DEFAULT_COLORS[0];
+      }
+    }
+  }
 });
 
 module.exports = Chart;

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -50,7 +50,6 @@ var Chart = React.createClass({
         height: '300px'
       },
       chartEvents : [],
-      chartAction: null,
       data: null,
       onSelect: null,
       legend_toggle: false
@@ -115,17 +114,6 @@ var Chart = React.createClass({
         self.chart = self.wrapper.getChart();
         // add the chart events
         self.listen_to_chart_events.call(this);
-
-        // if any action was specified, add it to the chart
-        if (self.props.chartAction != null){
-          var action_parameters = self.props.chartAction;
-          self.chart.setAction({
-            id: action_parameters.id,
-            text: action_parameters.text,
-            // bind the chart back to the action callback so we can get the chart information
-            action: action_parameters.action.bind(self.chart),
-          });
-        }
       }
     );
 
@@ -153,6 +141,16 @@ var Chart = React.createClass({
     for (var i = 0; i < this.props.chartEvents.length; i++) {
       if (this.props.chartEvents[i].eventName === 'ready') {
         this.props.chartEvents[i].callback(this);
+      }
+      else if (this.props.chartEvents[i].eventName === 'action') {
+        // if any action was specified, add it to the chart
+        var action_parameters = this.props.chartEvents[i].callback;
+        self.chart.setAction({
+          id: action_parameters.id,
+          text: action_parameters.text,
+          // bind the chart back to the action callback so we can get the chart information
+          action: action_parameters.action.bind(self.chart),
+        });
       }
       else {
         (function(callback){

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -96,6 +96,7 @@ var Chart = React.createClass({
       this.data_table = this.build_data_table();
     }
 
+    // creates the google wrapper
     this.wrapper = new google.visualization.ChartWrapper({
       chartType: this.props.chartType,
       dataTable: this.data_table,
@@ -106,13 +107,25 @@ var Chart = React.createClass({
     this.data_table = this.wrapper.getDataTable();
 
     var self = this;
-
     google.visualization.events.addOneTimeListener(
       this.wrapper,
       'ready',
       function() {
+        // when the wrapper is ready, define the chart
         self.chart = self.wrapper.getChart();
+        // add the chart events
         self.listen_to_chart_events.call(this);
+
+        // if any action was specified, add it to the chart
+        if (self.props.chartAction != null){
+          var action_parameters = self.props.chartAction;
+          self.chart.setAction({
+            id: action_parameters.id,
+            text: action_parameters.text,
+            // bind the chart back to the action callback so we can get the chart information
+            action: action_parameters.action.bind(self.chart),
+          });
+        }
       }
     );
 
@@ -130,13 +143,6 @@ var Chart = React.createClass({
         'select',
         function() { self.props.onSelect(self, self.chart.getSelection()); }
       );
-    }
-
-    if (this.props.chartAction){
-      var action_parameters = this.props.action;
-      // pass the chart wrapper back to the action callback
-      action_parameters.action = action_parameters.action.callback(this)
-      this.wrapper.setAction(action_parameters);
     }
 
     self.wrapper.draw();


### PR DESCRIPTION
Hi
This allows the Google Chart [Tooltip Action](https://developers.google.com/chart/interactive/docs/customizing_tooltip_content#tooltip-actions) feature. 

I decided to use the existing `chartEvents` list to pass the `setAction` kwargs list.
However this commit [8be97d8](https://github.com/RakanNimer/react-google-charts/commit/8be97d8cad45533287570302c522e419dafe964f) uses a new `chartAction` props.

Open to suggestion on which method is best =)

Example of use:
```javascript
componentDidMount: function() {
    var chartEvents = [{
        eventName: 'action',
        callback: {
          id: 'action', text: 'click me',
          action: function (){
            console.log(this.getSelection()[0]) // prints currently selected col and row
          } }
    }];
}
```
Cheers