### PR TITLE
enable description objects instead of explicitly setting type and label

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -64,7 +64,7 @@ var Chart = React.createClass({
 
 		var data_table = new google.visualization.DataTable();
 		for (var i = 0 ; i < this.props.columns.length; i++) {
-			data_table.addColumn(this.props.columns[i].type, this.props.columns[i].label);
+			data_table.addColumn(this.props.columns[i]);
 		}
 
 		if (this.props.rows.length > 0) {


### PR DESCRIPTION
The `DataTable.addColumn` method allows a `description_object` to be passed: https://developers.google.com/chart/interactive/docs/reference#methods

I think this is a better way to handle the data columns instead of explicitly looking for `type` and `label`.

This will also fix the other pull request to enable `tooltips`.