### PR TITLE
React 0.14 + animation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/rakannimer/react-google-charts",
   "dependencies": {
     "q": "^1.4.1",
-    "react": "^0.13.3",
+    "react": "^0.14.0",
     "react-tools": "^0.13.3",
     "jquery": "^2.1.4"
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/rakannimer/react-google-charts",
   "dependencies": {
     "q": "^1.4.1",
-    "react": "^0.14.0",
+    "react": ">=0.13.3",
     "react-tools": "^0.13.3",
     "jquery": "^2.1.4"
   }

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -3,7 +3,7 @@ var GoogleChartLoader = require('./GoogleChartLoader');
 var DEFAULT_COLORS = require('../constants/DEFAULT_CHART_COLORS');
 
 var uniqueId = 0;
-var generateUniqueId = function () {
+var generateUniqueId = function() {
 	uniqueId++;
 	return "reactgooglegraph" + uniqueId;
 };
@@ -13,29 +13,28 @@ var Chart = React.createClass({
 	wrapper: null,
 	hidden_columns: [],
 	data_table: [],
-	getInitialState: function () {
+	getInitialState: function() {
 		return {
 			graph_id: this.props.graph_id || generateUniqueId()
 		};
 	},
-	componentDidMount: function () {
+	componentDidMount: function(){
 		var self = this;
 
-		GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function () {
+		GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function(){
 			self.drawChart();
 		});
 	},
 
-	componentDidUpdate: function () {
-		if (GoogleChartLoader.is_loaded) {
+	componentDidUpdate: function(){
+		if (GoogleChartLoader.is_loaded){
 			this.drawChart();
-		}
-		;
+		};
 	},
 
-	getDefaultProps: function () {
+	getDefaultProps: function() {
 		return {
-			chartType: 'LineChart',
+			chartType : 'LineChart',
 			rows: [],
 			columns: [],
 			options: {
@@ -49,8 +48,8 @@ var Chart = React.createClass({
 				height: '300px'
 
 			},
-			chartEvents: [],
-			chartActions: null,
+			chartEvents : [],
+			chartActions : null,
 			data: null,
 			onSelect: null,
 			legend_toggle: false
@@ -58,13 +57,14 @@ var Chart = React.createClass({
 	},
 
 
-	render: function () {
-		return React.DOM.div({id: this.state.graph_id, style: {height: this.props.height, width: this.props.width}});
+
+	render: function() {
+		return React.DOM.div({id: this.state.graph_id, style: {height: this.props.height, width:this.props.width}});
 	},
-	build_data_table: function () {
+	build_data_table : function() {
 
 		var data_table = new google.visualization.DataTable();
-		for (var i = 0; i < this.props.columns.length; i++) {
+		for (var i = 0 ; i < this.props.columns.length; i++) {
 			data_table.addColumn(this.props.columns[i]);
 		}
 
@@ -73,8 +73,7 @@ var Chart = React.createClass({
 		}
 		return data_table;
 	},
-
-	update_data_table: function () {
+	update_data_table : function() {
 		this.data_table.removeRows(0, this.data_table.getNumberOfRows());
 		this.data_table.removeColumns(0, this.data_table.getNumberOfColumns());
 
@@ -87,7 +86,7 @@ var Chart = React.createClass({
 		}
 	},
 
-	drawChart: function () {
+	drawChart: function() {
 
 		if ((this.props.data !== null && this.props.data.length === 0) || this.props.columns.length === 0) {
 			return;
@@ -132,8 +131,7 @@ var Chart = React.createClass({
 		}
 		this.wrapper.draw();
 	},
-
-	listen_to_chart_events: function () {
+	listen_to_chart_events: function() {
 
 		var self = this;
 		var event_data;
@@ -142,11 +140,11 @@ var Chart = React.createClass({
 				this.props.chartEvents[i].callback(this);
 			}
 			else {
-				(function (callback) {
+				(function(callback){
 					google
 							.visualization
 							.events
-							.addListener(self.chart, self.props.chartEvents[i].eventName, function (e) {
+							.addListener(self.chart, self.props.chartEvents[i].eventName, function (e){
 								callback(self, e);
 							});
 				})(self.props.chartEvents[i].callback)
@@ -163,10 +161,9 @@ var Chart = React.createClass({
 				// bind the chart back to the action callback so we can get the chart information
 				action: this.props.chartActions.action.bind(self.chart)
 			});
-		}
-		;
+		};
 	},
-	default_chart_select: function () {
+	default_chart_select: function() {
 		var selection = this.chart.getSelection();
 		// if selection length is 0, we deselected an element
 		if (selection.length > 0) {
@@ -178,7 +175,7 @@ var Chart = React.createClass({
 		}
 	},
 
-	build_empty_column: function (index) {
+	build_empty_column: function(index) {
 
 		return {
 			label: this.data_table.getColumnLabel(index),
@@ -189,7 +186,7 @@ var Chart = React.createClass({
 		};
 	},
 
-	build_column_from_src: function (index) {
+	build_column_from_src: function(index) {
 		return {
 			label: this.data_table.getColumnLabel(index),
 			type: this.data_table.getColumnType(index),
@@ -197,7 +194,7 @@ var Chart = React.createClass({
 		};
 	},
 
-	toggle_points: function (column) {
+	toggle_points: function(column) {
 
 		//Need to show legend !!
 
@@ -213,17 +210,17 @@ var Chart = React.createClass({
 		for (var i = 0; i < column_count; i++) {
 
 			// If user clicked on legend
-			if (i === column) {
+			if (i === column ) {
 
 				column_hidden = (typeof this.hidden_columns[i] !== 'undefined');
 
 				//User wants to hide values
-				if (!column_hidden) {
+				if (!column_hidden ) {
 					// Null out the values of the column
-					empty_column = this.build_empty_column(i);
+					empty_column =  this.build_empty_column(i);
 					columns.push(empty_column);
 
-					this.hidden_columns[i] = {color: this.get_column_color(i - 1)};
+					this.hidden_columns[i] = { color : this.get_column_color(i-1) };
 					colors.push('#CCCCCC');
 				}
 				//User wants to show values
@@ -237,7 +234,7 @@ var Chart = React.createClass({
 				}
 			}
 			else if (typeof this.hidden_columns[i] !== 'undefined') {
-				empty_column = this.build_empty_column(i);
+				empty_column =  this.build_empty_column(i);
 				columns.push(empty_column);
 				colors.push('#CCCCCC');
 			}
@@ -246,7 +243,7 @@ var Chart = React.createClass({
 				columns.push(column_from_src);
 
 				if (i !== 0) {
-					colors.push(this.get_column_color(i - 1));
+					colors.push(this.get_column_color(i-1));
 				}
 			}
 		}
@@ -258,7 +255,7 @@ var Chart = React.createClass({
 	},
 
 
-	get_column_color: function (column_index) {
+	get_column_color: function(column_index) {
 		if (this.props.options.colors) {
 			if (this.props.options.colors[column_index]) {
 				return this.props.options.colors[column_index];

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -3,9 +3,9 @@ var GoogleChartLoader = require('./GoogleChartLoader');
 var DEFAULT_COLORS = require('../constants/DEFAULT_CHART_COLORS');
 
 var uniqueId = 0;
-var generateUniqueId = function() {
-    uniqueId++;
-    return "reactgooglegraph" + uniqueId;
+var generateUniqueId = function () {
+	uniqueId++;
+	return "reactgooglegraph" + uniqueId;
 };
 
 var Chart = React.createClass({
@@ -13,28 +13,29 @@ var Chart = React.createClass({
 	wrapper: null,
 	hidden_columns: [],
 	data_table: [],
-	getInitialState: function() {
+	getInitialState: function () {
 		return {
-            graph_id: this.props.graph_id || generateUniqueId()
+			graph_id: this.props.graph_id || generateUniqueId()
 		};
 	},
-	componentDidMount: function(){
-	    var self = this;
+	componentDidMount: function () {
+		var self = this;
 
-	    GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function(){
-	      self.drawChart();
-	    });
+		GoogleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(function () {
+			self.drawChart();
+		});
 	},
 
-	componentDidUpdate: function(){
-		if (GoogleChartLoader.is_loaded){
+	componentDidUpdate: function () {
+		if (GoogleChartLoader.is_loaded) {
 			this.drawChart();
-		};
-  	},
+		}
+		;
+	},
 
-	getDefaultProps: function() {
+	getDefaultProps: function () {
 		return {
-			chartType : 'LineChart',
+			chartType: 'LineChart',
 			rows: [],
 			columns: [],
 			options: {
@@ -47,24 +48,23 @@ var Chart = React.createClass({
 				width: '400px',
 				height: '300px'
 
-	      	},
-	      	chartEvents : [],
-	      	chartActions : null,
-	      	data: null,
-	      	onSelect: null,
-	        legend_toggle: false
-	    };
+			},
+			chartEvents: [],
+			chartActions: null,
+			data: null,
+			onSelect: null,
+			legend_toggle: false
+		};
 	},
 
 
-
-	render: function() {
-		return React.DOM.div({id: this.state.graph_id, style: {height: this.props.height, width:this.props.width}});
+	render: function () {
+		return React.DOM.div({id: this.state.graph_id, style: {height: this.props.height, width: this.props.width}});
 	},
-	build_data_table : function() {
+	build_data_table: function () {
 
 		var data_table = new google.visualization.DataTable();
-		for (var i = 0 ; i < this.props.columns.length; i++) {
+		for (var i = 0; i < this.props.columns.length; i++) {
 			data_table.addColumn(this.props.columns[i]);
 		}
 
@@ -74,176 +74,192 @@ var Chart = React.createClass({
 		return data_table;
 	},
 
-	drawChart: function() {
+	update_data_table: function () {
+		this.data_table.removeRows(0, this.data_table.getNumberOfRows());
+		this.data_table.removeColumns(0, this.data_table.getNumberOfColumns());
 
-		if (this.props.data !== null ) {
-			if (this.props.data.length === 0 ) {
-				// Initialized. Do nothing and wait for data
-				return;
-			}
-
-			this.data_table = this.props.data;
+		for (var i = 0; i < this.props.columns.length; i++) {
+			this.data_table.addColumn(this.props.columns[i]);
 		}
-		else if (this.props.columns.length === 0) {
+
+		if (this.props.rows.length > 0) {
+			this.data_table.addRows(this.props.rows);
+		}
+	},
+
+	drawChart: function () {
+
+		if ((this.props.data !== null && this.props.data.length === 0) || this.props.columns.length === 0) {
 			return;
 		}
-		else {
-			this.data_table = this.build_data_table();
+
+		if (!this.wrapper) {
+			this.data_table = this.props.data !== null ? this.props.data : this.build_data_table();
+			this.wrapper = new google.visualization.ChartWrapper({
+				chartType: this.props.chartType,
+				dataTable: this.data_table,
+				options: this.props.options,
+				containerId: this.state.graph_id
+			});
+
+			this.data_table = this.wrapper.getDataTable();
+
+			var self = this;
+
+			google.visualization.events.addOneTimeListener(this.wrapper, 'ready', function () {
+				self.chart = self.wrapper.getChart();
+				self.listen_to_chart_events.call(this);
+				self.add_chart_actions.call(this);
+			});
+
+			if (this.props.legend_toggle) {
+				google.visualization.events.addListener(this.wrapper, 'select', function () {
+					self.default_chart_select.call(this);
+				});
+			}
+			if (this.props.onSelect !== null) {
+				google.visualization.events.addListener(this.wrapper, 'select', function () {
+					self.props.onSelect(self, self.chart.getSelection());
+				});
+			}
+		} else {
+			if (this.props.data !== null) {
+				this.wrapper.setDataTable(this.props.data);
+				this.data_table = this.wrapper.getDataTable();
+			} else {
+				this.update_data_table();
+			}
 		}
+		this.wrapper.draw();
+	},
 
+	listen_to_chart_events: function () {
 
-		this.wrapper = new google.visualization.ChartWrapper({
-			chartType: this.props.chartType,
-			dataTable: this.data_table,
-			options : this.props.options,
-			containerId: this.state.graph_id
-		});
-
-		this.data_table = this.wrapper.getDataTable();
-
-        var self = this;
-
-        google.visualization.events.addOneTimeListener(this.wrapper, 'ready', function() {
-        	self.chart = self.wrapper.getChart();
-        	self.listen_to_chart_events.call(this);
-        	self.add_chart_actions.call(this);
-        });
-
-        if (this.props.legend_toggle) {
-        	google.visualization.events.addListener(this.wrapper, 'select', function() { self.default_chart_select.call(this); });
-        }
-        if (this.props.onSelect !== null) {
-        	google.visualization.events.addListener(this.wrapper, 'select', function() { self.props.onSelect(self, self.chart.getSelection()); });
-        }
-        self.wrapper.draw();
-
-    },
-    listen_to_chart_events: function() {
-
-    	var self = this;
-    	var event_data;
-  		for (var i = 0; i < this.props.chartEvents.length; i++) {
-  			if (this.props.chartEvents[i].eventName === 'ready') {
-  				this.props.chartEvents[i].callback(this);
-  			}
-  			else {
-          (function(callback){
-            google
-              .visualization
-              .events
-              .addListener(self.chart, self.props.chartEvents[i].eventName, function (e){
-                callback(self, e);
-              });
-          })(self.props.chartEvents[i].callback)
-  			}
-		  }
-    },
-    add_chart_actions: function () {
-    	var self = this;
-      // if any action was specified, add it to the chart
-      if (this.props.chartActions != null) {
-        self.chart.setAction({
-          id: this.props.chartActions.id,
-          text: this.props.chartActions.text,
-          // bind the chart back to the action callback so we can get the chart information
-          action: this.props.chartActions.action.bind(self.chart)
-        });
-      };
-    },
-    default_chart_select: function() {
+		var self = this;
+		var event_data;
+		for (var i = 0; i < this.props.chartEvents.length; i++) {
+			if (this.props.chartEvents[i].eventName === 'ready') {
+				this.props.chartEvents[i].callback(this);
+			}
+			else {
+				(function (callback) {
+					google
+							.visualization
+							.events
+							.addListener(self.chart, self.props.chartEvents[i].eventName, function (e) {
+								callback(self, e);
+							});
+				})(self.props.chartEvents[i].callback)
+			}
+		}
+	},
+	add_chart_actions: function () {
+		var self = this;
+		// if any action was specified, add it to the chart
+		if (this.props.chartActions != null) {
+			self.chart.setAction({
+				id: this.props.chartActions.id,
+				text: this.props.chartActions.text,
+				// bind the chart back to the action callback so we can get the chart information
+				action: this.props.chartActions.action.bind(self.chart)
+			});
+		}
+		;
+	},
+	default_chart_select: function () {
 		var selection = this.chart.getSelection();
-	    // if selection length is 0, we deselected an element
-	    if (selection.length > 0) {
-	        // if row is undefined, we clicked on the legend
-	        if (selection[0].row == null) {
-	        	var column = selection[0].column;
-	        	this.toggle_points(column);
-	        }
-	    }
-    },
+		// if selection length is 0, we deselected an element
+		if (selection.length > 0) {
+			// if row is undefined, we clicked on the legend
+			if (selection[0].row == null) {
+				var column = selection[0].column;
+				this.toggle_points(column);
+			}
+		}
+	},
 
-    build_empty_column: function(index) {
+	build_empty_column: function (index) {
 
-    	return {
+		return {
 			label: this.data_table.getColumnLabel(index),
-            type: this.data_table.getColumnType(index),
-            calc: function () {
-                return null;
-            }
+			type: this.data_table.getColumnType(index),
+			calc: function () {
+				return null;
+			}
 		};
-    },
+	},
 
-    build_column_from_src: function(index) {
-    	return {
+	build_column_from_src: function (index) {
+		return {
 			label: this.data_table.getColumnLabel(index),
 			type: this.data_table.getColumnType(index),
 			sourceColumn: index
 		};
-    },
+	},
 
-    toggle_points: function(column) {
+	toggle_points: function (column) {
 
 		//Need to show legend !!
 
-    	var view = new google.visualization.DataView(this.wrapper.getDataTable());
-    	var column_count = view.getNumberOfColumns();
-    	var colors = [],
-    		columns = [],
-			empty_columns = [],
-			column_hidden,
-			empty_column,
-			column_from_src;
+		var view = new google.visualization.DataView(this.wrapper.getDataTable());
+		var column_count = view.getNumberOfColumns();
+		var colors = [],
+				columns = [],
+				empty_columns = [],
+				column_hidden,
+				empty_column,
+				column_from_src;
 
 		for (var i = 0; i < column_count; i++) {
 
 			// If user clicked on legend
-			if (i === column ) {
+			if (i === column) {
 
 				column_hidden = (typeof this.hidden_columns[i] !== 'undefined');
 
 				//User wants to hide values
-				if (!column_hidden ) {
+				if (!column_hidden) {
 					// Null out the values of the column
-					empty_column =  this.build_empty_column(i);
+					empty_column = this.build_empty_column(i);
 					columns.push(empty_column);
 
-					this.hidden_columns[i] = { color : this.get_column_color(i-1) };
+					this.hidden_columns[i] = {color: this.get_column_color(i - 1)};
 					colors.push('#CCCCCC');
 				}
 				//User wants to show values
 				else {
 					column_from_src = this.build_column_from_src(i);
-    				columns.push(column_from_src);
+					columns.push(column_from_src);
 
-    				var previous_color = this.hidden_columns[i].color;
-    				delete this.hidden_columns[i];
-    				colors.push(previous_color);
+					var previous_color = this.hidden_columns[i].color;
+					delete this.hidden_columns[i];
+					colors.push(previous_color);
 				}
 			}
 			else if (typeof this.hidden_columns[i] !== 'undefined') {
-				empty_column =  this.build_empty_column(i);
+				empty_column = this.build_empty_column(i);
 				columns.push(empty_column);
 				colors.push('#CCCCCC');
 			}
 			else {
 				column_from_src = this.build_column_from_src(i);
-    			columns.push(column_from_src);
+				columns.push(column_from_src);
 
-					if (i !== 0) {
-						colors.push(this.get_column_color(i-1));
-					}
+				if (i !== 0) {
+					colors.push(this.get_column_color(i - 1));
+				}
 			}
 		}
 
 		view.setColumns(columns);
-    	this.props.options.colors = colors;
+		this.props.options.colors = colors;
 
-    	this.chart.draw(view, this.props.options);
-    },
+		this.chart.draw(view, this.props.options);
+	},
 
 
-    get_column_color: function(column_index) {
-    	if (this.props.options.colors) {
+	get_column_color: function (column_index) {
+		if (this.props.options.colors) {
 			if (this.props.options.colors[column_index]) {
 				return this.props.options.colors[column_index];
 			}
@@ -257,7 +273,7 @@ var Chart = React.createClass({
 			}
 
 		}
-    }
+	}
 
 });
 


### PR DESCRIPTION
React 0.14: see https://github.com/RakanNimer/react-google-charts/issues/13

Animation support:

Whenever the Chart component is updated, a new wrapper and table_data are created. This seems to prevent animations when the columns/rows in the props are changed. 

The pull request modifies the code so the wrapper is not created again if it already exists. 

table_data is either:
  - if data is passed in props.rows and props.columns, table_data is not recreated. table_data is emptied, and filled with the values from props.rows and props.columns. This makes animations work.
  - if data is passed with props.data, a new table_data is created, and passed to the existing wrapper. I have not checked whether this allows animations.
