### PR TITLE
Replace jquery with scriptjs and make ready for react 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,9 @@
   "homepage": "https://github.com/rakannimer/react-google-charts",
   "dependencies": {
     "q": "^1.4.1",
-    "react": ">=0.13.3",
-    "react-tools": "^0.13.3",
-    "jquery": "^2.1.4"
+    "scriptjs": "^2.5.8"
+  },
+  "peerDependencies": {
+    "react": "^0.14"
   }
 }

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -59,7 +59,7 @@ var Chart = React.createClass({
 
 
 	render: function() {
-		return React.DOM.div({id: this.state.graph_id, style: {height: this.props.height, width:this.props.width}});
+		return React.createElement("div", {id: this.state.graph_id, style: {height: this.props.height, width:this.props.width}})
 	},
 	build_data_table : function() {
 

--- a/src/components/GoogleChartLoader.js
+++ b/src/components/GoogleChartLoader.js
@@ -2,42 +2,32 @@
 
 // Based on http://blog.arkency.com/2014/09/react-dot-js-and-google-charts/
 var q = require('q');
-var $ = require('jquery');
+var script = require("scriptjs")
 
 var GoogleChartLoader = function(){
 
 	this.is_loading = false;
 	this.is_loaded = false;
 	this.google_promise = q.defer();
-	this.url = "https://www.google.com/jsapi";
-	this.packages = ["corechart"];
-	this.version = "1";
-	this.init = function(packages, version) {
 
+	var self = this;
+
+	this.init = function(packages, version) {
+		// Charts can only be loaded once because of the way google implemented this
+		// Remember to load all packages you need at the first call
 		if (this.is_loading) {
 			return this.google_promise.promise;
 		}
+		script("https://www.gstatic.com/charts/loader.js", function() {
+			google.charts.load(version || 'current', {packages: packages || ['corechart']});
+			google.charts.setOnLoadCallback(function() {
+			self.is_loaded = true;
+  			self.google_promise.resolve();
+			})
+		})
 
-		this.is_loading = true;
-		var self = this;
-
-	 	var options = {
-	    	dataType: "script",
-	    	cache: true,
-	    	url: this.url,
-	  	};
-	  	$.ajax(options).done(
-	  		function(){
-	    		google.load("visualization", version || self.version, {
-	      			packages: packages || self.packages,
-	      			callback: function() {
-	      				self.is_loaded = true;
-	        			self.google_promise.resolve();
-	      			}
-	    		});
-	    });
-	    return this.google_promise.promise;
-	}
+		return this.google_promise.promise;
+	};
 };
 
 module.exports = new GoogleChartLoader();

--- a/src/components/GoogleChartLoader.js
+++ b/src/components/GoogleChartLoader.js
@@ -18,11 +18,12 @@ var GoogleChartLoader = function(){
 		if (this.is_loading) {
 			return this.google_promise.promise;
 		}
+		this.is_loading = true
 		script("https://www.gstatic.com/charts/loader.js", function() {
 			google.charts.load(version || 'current', {packages: packages || ['corechart']});
 			google.charts.setOnLoadCallback(function() {
-			self.is_loaded = true;
-  			self.google_promise.resolve();
+				self.is_loaded = true;
+  				self.google_promise.resolve();
 			})
 		})
 


### PR DESCRIPTION
Scriptjs is a smaller dependency.
createElement and peerDependency makes it compatible with react 0.14. Probably still compatible with react 0.13 but I haven't tested that.