### PR TITLE
Fix refreshing chart options

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -122,6 +122,7 @@ var Chart = React.createClass({
 				});
 			}
 		} else {
+			this.wrapper.setOptions(this.props.options);
 			if (this.props.data !== null) {
 				this.wrapper.setDataTable(this.props.data);
 				this.data_table = this.wrapper.getDataTable();


### PR DESCRIPTION
Fixing a bug with chart options. Once the wrapper was created,
options were no longer updated. We should pass them every time a chart
is drawn.