### PR TITLE
Fix logic bug in drawChart

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -88,7 +88,7 @@ var Chart = React.createClass({
 
 	drawChart: function() {
 
-		if ((this.props.data !== null && this.props.data.length === 0) || this.props.columns.length === 0) {
+		if ((this.props.data !== null && this.props.data.length === 0) || (this.props.data === null && this.props.columns.length === 0)) {
 			return;
 		}
 


### PR DESCRIPTION
without `this.props.data === null` in the right hand side of the `||` clause, it will *always* yield true if you provide just a `data` property because
`this.props.columns.length === 0` is initialized to 0.