### PR TITLE
Check charts exist before remove event handlers

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -54,7 +54,9 @@ export default class Chart extends React.Component {
   }
   componentWillUnmount() {
     try {
-      window.google.visualization.events.removeAllListeners(this.wrapper);
+      if (window.google && window.google.visualization) {
+        window.google.visualization.events.removeAllListeners(this.wrapper);
+      }
     } catch (err) {
       console.error('Error removing events, error : ', err);
     }


### PR DESCRIPTION
Prevent error being thrown unnecessarily by checking that the google objects have been created on the window before trying to remove the listeners 