### PR TITLE
Fix onResize event listener. Fixes #108

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -48,8 +48,8 @@ export default class Chart extends React.Component {
       googleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(() => {
         this.drawChart();
       });
-      window.addEventListener('resize', this.onResize);
       this.onResize = this.debounce(this.onResize, 200);
+      window.addEventListener('resize', this.onResize);      
     } else {
       this.drawChart();
     }


### PR DESCRIPTION
The onResize function attached using addEventListener was changed by the debounce function call, thus the listener is not removed.