### PR TITLE
Update PropsEditor.js to use 'prop-types' package

### DIFF
--- a/src/components/PropsEditor.js
+++ b/src/components/PropsEditor.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class StateEditor extends React.Component {
   constructor(props) {
@@ -34,7 +35,7 @@ export default class StateEditor extends React.Component {
 }
 
 StateEditor.propTypes = {
-  inputValue: React.PropTypes.string,
-  chartIndex: React.PropTypes.number,
-  onSubmit: React.PropTypes.func,
+  inputValue: PropTypes.string,
+  chartIndex: PropTypes.number,
+  onSubmit: PropTypes.func,
 };


### PR DESCRIPTION
First, great work on this package!

In my search to see which dependencies were still using `React.PropTypes` (and causing React 15.6 to yell at me), I found this little guy was behind the times. `PropsEditor.js` (and this package in general) isn't causing any warnings, but I figured it couldn't hurt to bring this last file into the modern React era 😄 

- [X] Import `prop-types` into file and replace `React.PropTypes` with `PropTypes`