### PR TITLE
Allow React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "debug": "^2.2.0",
     "loadjs": "^3.3.1",
     "prop-types": "^15.5.8",
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react": "^15.3.2 || ^16",
+    "react-dom": "^15.3.2 || ^16"
   },
   "peerDependencies": {
     "react": ">= 0.13.x",


### PR DESCRIPTION
I just tried to upgrade to React 16 and found that this package is forcing an install of 15 which clashes and causes React to cry. 😢 

This fix is how the official `create-react-app` package for `react-error-overlay` handles their React dependencies, so it should be a reliable solution.