### PR TITLE
add mapsApiKey for GeoChart

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -46,9 +46,10 @@ export default class Chart extends React.Component {
       return;
     }
     if (this.props.loadCharts) {
-      googleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(() => {
-        this.drawChart();
-      });
+      googleChartLoader.init(this.props.chartPackages, this.props.chartVersion,
+          this.props.mapsApiKey).then(() => {
+            this.drawChart();
+          });
       this.onResize = this.debounce(this.onResize, 200);
       window.addEventListener('resize', this.onResize);
     } else {
@@ -250,7 +251,9 @@ export default class Chart extends React.Component {
       label: this.dataTable.getColumnLabel(columnIndex),
       type: this.dataTable.getColumnType(columnIndex),
       sourceColumn: columnIndex,
-      role: this.dataTable.getColumnRole(columnIndex) // addedBy minam.cho(devbada) cause of 'All series on a given axis must be of the same data type': July 10, 2017
+      // addedBy minam.cho(devbada) cause of 'All series on a given
+      // axis must be of the same data type': July 10, 2017
+      role: this.dataTable.getColumnRole(columnIndex),
     };
   }
 
@@ -260,7 +263,9 @@ export default class Chart extends React.Component {
       label: this.dataTable.getColumnLabel(columnIndex),
       type: this.dataTable.getColumnType(columnIndex),
       calc: () => null,
-      role: this.dataTable.getColumnRole(columnIndex) // addedBy minam.cho(devbada) cause of 'All series on a given axis must be of the same data type': July 10, 2017
+      // addedBy minam.cho(devbada) cause of 'All series on a given
+      // axis must be of the same data type': July 10, 2017
+      role: this.dataTable.getColumnRole(columnIndex),
     };
   }
   addEmptyColumnTo(columns, columnIndex) {
@@ -378,6 +383,7 @@ Chart.propTypes = {
   allowEmptyRows: PropTypes.bool,
   chartPackages: PropTypes.arrayOf(PropTypes.string),
   chartVersion: PropTypes.string,
+  mapsApiKey: PropTypes.string,
   numberFormat: PropTypes.shape({
     column: PropTypes.number, // eslint-disable-line react/no-unused-prop-types
     options: PropTypes.shape({

--- a/src/components/GoogleChartLoader.js
+++ b/src/components/GoogleChartLoader.js
@@ -11,15 +11,19 @@ const googleChartLoader = {
   isLoaded: false,
   isLoading: false,
   initPromise: {},
-  init: function init(packages, version) {
-    debug('init', packages, version);
+  init: function init(packages, version, mapsApiKey) {
+    debug('init', packages, version, mapsApiKey);
     if (this.isLoading || this.isLoaded) {
       return this.initPromise;
     }
     this.isLoading = true;
     this.initPromise = new Promise((resolve) => {
       script('https://www.gstatic.com/charts/loader.js', { success: () => {
-        window.google.charts.load(version || 'current', { packages: packages || ['corechart'] });
+        const opts = { packages: packages || ['corechart'] };
+        if (mapsApiKey) {
+          opts.mapsApiKey = mapsApiKey;
+        }
+        window.google.charts.load(version || 'current', opts);
         window.google.charts.setOnLoadCallback(() => {
           debug('Chart Loaded');
           this.isLoaded = true;


### PR DESCRIPTION
The following code works for me in demo mode, but I have some problems importing this into a real project.  Is there someone who wants to try this out before merging it?

Here's an example:

```jsx
// demo/src/App.js
import React from 'react';
import Chart from '../../src/components/Chart';

const options = {
    //displayMode: "markers"
    //displayMode: "text"
};

const data = [
    ["ca", 3],
    ["ru", 4],
    ["us", 5],
    ["gb", 5]
];
const columns = [
    {
        "type": "string",
        "label" : "Country"
    }, {
        "type": "number",
        "label": "Students"
    }];
const App = () => (
  <div className={'my-pretty-chart-container'}>
      <Chart chartType="GeoChart"
             width={"900px"}
             height={"500px"}
             rows={data}
             columns={columns}
             options={options}
             graph_id="GeoChart"
             mapsApiKey="APIKEYHERE"
             legend_toggle={false}/>
  </div>
);
export default App;
```

