### PR TITLE
Add support to load a different language

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -46,7 +46,7 @@ export default class Chart extends React.Component {
       return;
     }
     if (this.props.loadCharts) {
-      googleChartLoader.init(this.props.chartPackages, this.props.chartVersion).then(() => {
+      googleChartLoader.init(this.props.chartPackages, this.props.chartVersion, this.props.chartLanguage).then(() => {
         this.drawChart();
       });
       this.onResize = this.debounce(this.onResize, 200);
@@ -378,6 +378,7 @@ Chart.propTypes = {
   allowEmptyRows: PropTypes.bool,
   chartPackages: PropTypes.arrayOf(PropTypes.string),
   chartVersion: PropTypes.string,
+  chartLanguage: PropTypes.string,
   numberFormat: PropTypes.shape({
     column: PropTypes.number, // eslint-disable-line react/no-unused-prop-types
     options: PropTypes.shape({
@@ -431,6 +432,7 @@ Chart.defaultProps = {
   loader: <div>Rendering Chart</div>,
   chartPackages: ['corechart'],
   chartVersion: 'current',
+  chartLanguage: 'en',
   numberFormat: null,
   dateFormat: null,
   diffdata: null,

--- a/src/components/GoogleChartLoader.js
+++ b/src/components/GoogleChartLoader.js
@@ -11,15 +11,15 @@ const googleChartLoader = {
   isLoaded: false,
   isLoading: false,
   initPromise: {},
-  init: function init(packages, version) {
-    debug('init', packages, version);
+  init: function init(packages, version, language) {
+    debug('init', packages, version, language);
     if (this.isLoading || this.isLoaded) {
       return this.initPromise;
     }
     this.isLoading = true;
     this.initPromise = new Promise((resolve) => {
       script('https://www.gstatic.com/charts/loader.js', { success: () => {
-        window.google.charts.load(version || 'current', { packages: packages || ['corechart'] });
+        window.google.charts.load(version || 'current', { packages: packages || ['corechart'], language: language || 'en' });
         window.google.charts.setOnLoadCallback(() => {
           debug('Chart Loaded');
           this.isLoaded = true;


### PR DESCRIPTION
This change in to add support for different languages when loading the Google Charts as documented [here](https://developers.google.com/chart/interactive/docs/basic_load_libs#loadwithlocale).

I couldn't run the lint and the tests.  It seems that some dependencies are not included in the `package.json`.

