### PR TITLE
Add flexible and idiomatic way to handle formatters.

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -142,24 +142,45 @@ export default class Chart extends React.Component {
       dataTable.addColumn(column);
     });
     dataTable.addRows(this.props.rows);
+    
+    const applyNumberFormat = (column, options) => {
+      const formatter = new window.google.visualization.NumberFormat(options);
+      formatter.format(dataTable, column);
+    }
+    
+    const applyDateFormat = (column, options) => {
+      const formatter = new window.google.visualization.DateFormat(options);
+      formatter.format(dataTable, column);
+    }
+    
     if (this.props.numberFormat) {
-      const formatter = new window.google.visualization.NumberFormat(
-        this.props.numberFormat.options
-      );
-      formatter.format(dataTable, this.props.numberFormat.column);
+      const { column, options } = this.props.numberFormat;
+      this.applyNumberFormat(column, options);
     }
 
     if (this.props.dateFormat) {
-      const dateFormat = new window.google.visualization.DateFormat(
-        this.props.dateFormat.options
-      );
-      this.props.dateFormat.columns.forEach((columnIdx) => {
-        dateFormat.format(dataTable, columnIdx);
+      const { columns, options } = this.props.dateFormat;
+      columns.forEach((col) => {
+        this.applyDateFormat(col, options)
       });
+    }
+    
+    this.props.formatters.forEach((formatter) => {
+      const { type, column, options } = formatter;
+      switch (type) {
+        case 'NumberFormat':
+          this.applyNumberFormat(column, options);
+        case 'DateFormat':
+          this.applyDateFormat(column, options);
+        default:
+          console.log('Unkown formatter type: ' + type);
+          break;
+      }
     }
 
     return dataTable;
   }
+
   updateDataTable() {
     debug('updateDataTable');
     window.google.visualization.errors.removeAll(
@@ -433,5 +454,6 @@ Chart.defaultProps = {
   chartVersion: 'current',
   numberFormat: null,
   dateFormat: null,
+  formatters: [],
   diffdata: null,
 };

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -165,8 +165,11 @@ export default class Chart extends React.Component {
       });
     }
     
-    this.props.formatters.forEach((formatter) => {
-      const { type, column, options } = formatter;
+    this.props.formatters.forEach(({ 
+      type, 
+      column, 
+      options 
+    }) => {
       switch (type) {
         case 'NumberFormat':
           this.applyNumberFormat(column, options);
@@ -176,7 +179,7 @@ export default class Chart extends React.Component {
           console.log('Unkown formatter type: ' + type);
           break;
       }
-    }
+    });
 
     return dataTable;
   }


### PR DESCRIPTION
This change enables applying NumberFormat and DateFormat to multiple columns. It's also flexible and could be easily extended to include the other Formatters (e.g. ArrowFormat, BarFormat, etc.)
https://developers.google.com/chart/interactive/docs/reference#formatters

