### PR TITLE
Don't remove rows or columns on the dataTable in updateTable

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -203,8 +203,6 @@ export default class Chart extends React.Component {
     window.google.visualization.errors.removeAll(
       document.getElementById(this.wrapper.getContainerId())
     );
-    this.dataTable.removeRows(0, this.dataTable.getNumberOfRows());
-    this.dataTable.removeColumns(0, this.dataTable.getNumberOfColumns());
     this.dataTable = this.buildDataTableFromProps();
     return this.dataTable;
   }
@@ -425,7 +423,10 @@ Chart.propTypes = {
   chartType: PropTypes.string,
   rows: PropTypes.arrayOf(PropTypes.array),
   columns: PropTypes.arrayOf(PropTypes.object),
-  data: PropTypes.arrayOf(PropTypes.array),
+  data: PropTypes.shape({
+    cols: PropTypes.array,
+    rows: PropTypes.array
+  }),
   options: PropTypes.any,
   width: PropTypes.string,
   height: PropTypes.string,

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -73,6 +73,7 @@ export default class Chart extends React.Component {
     }
   }
   componentWillUnmount() {
+    this.isUnmounted = true;
     try {
       if (window) {
         if (window.google && window.google.visualization) {
@@ -210,6 +211,11 @@ export default class Chart extends React.Component {
 
   drawChart() {
     debug('drawChart', this);
+
+    if (this.isUnmounted) {
+      return;
+    }
+
     if (!this.wrapper) {
       const chartConfig = {
         chartType: this.props.chartType,


### PR DESCRIPTION
Calling removeRows and removeColumns mutates the `this.props.data` object which causes the data to disappear on Resize and something on load.