### PR TITLE
Fix resize issue in Chart.js

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -52,9 +52,9 @@ export default class Chart extends React.Component {
         )
         .then(() => {
           this.drawChart();
+          this.onResize = this.debounce(this.onResize, 200);
+          window.addEventListener('resize', this.onResize);
         });
-      this.onResize = this.debounce(this.onResize, 200);
-      window.addEventListener('resize', this.onResize);
     } else {
       this.drawChart();
     }

--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -73,6 +73,7 @@ export default class Chart extends React.Component {
     }
   }
   componentWillUnmount() {
+    this.isUnmounted = true;
     try {
       if (window) {
         if (window.google && window.google.visualization) {
@@ -210,6 +211,11 @@ export default class Chart extends React.Component {
 
   drawChart() {
     debug('drawChart', this);
+
+    if (this.isUnmounted) {
+      return;
+    }
+
     if (!this.wrapper) {
       const chartConfig = {
         chartType: this.props.chartType,


### PR DESCRIPTION
Start listening to a resize event only after to=he component is fully loaded and can exec draw.

When having a bad-connection, sometimes the registration for the "resize" event happens before the component has finished loading. This happens since the registration is done synchronously and not when the component is ready. In mobile web situation where users can quickly rotate their devices from portrait to landscape views, the resize happens and a client side exception is being thrown that the Chart is undefined, or Google visualisation is undefined.
This fixed it for me.

BTW - there are linting issues within this project, that I thought you should look at, since I don't feel confident enough to delete variables that are not being used... :)