### PR TITLE
Turn on loading flag while loading, fixes #195 and #197

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,7 @@ class GoogleChartLoader {
           }
         });
       });
+      this.isLoading = true
       return this.loadScript;
     };
   }

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ class GoogleChartLoader {
     this.destroy = () => {
       this.isLoading = false;
       this.isLoaded = false;
-      this.loadScript === null;
+      this.loadScript = null;
     };
     this.init = (packages, version, language, mapsApiKey) => {
       if ((this.isLoading || this.isLoaded) && this.loadScript !== null) {


### PR DESCRIPTION
Loading flag was not being set while loading, making multiple charts on the same page break. Note that you still need to have unique graph id values for each chart in order for each to be loading after initializiation