### PR TITLE
Fixes "Error: Google Charts loader.js can only be loaded once"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,22 +66,31 @@ class GoogleChartLoader {
         typeof window !== "undefined"
           ? require("loadjs")
           : (link, { success: callback }) => callback();
-      this.loadScript = new Promise(resolve => {
-        script("https://www.gstatic.com/charts/loader.js", {
-          success: () => {
-            const google_charts = getGoogleCharts(window);
-            google_charts.load(version || "current", {
-              packages: packages || ["corechart"],
-              language: language || "en",
-              mapsApiKey
-            });
-            google_charts.setOnLoadCallback(() => {
-              this.isLoaded = true;
-              this.isLoading = false;
-              resolve();
-            });
-          }
+        const loadGCharts = (gchart) =>{
+          gchart.load(version || "current", {
+          packages: packages || ["corechart"],
+          language: language || "en",
+          mapsApiKey
         });
+      }    
+      this.loadScript = new Promise(resolve => {
+        if(window.google && typeof window.google.charts !== 'undefined'){
+          const google_charts = getGoogleCharts(window);
+          loadGCharts(google_charts);
+          resolve();
+        }else{
+          script("https://www.gstatic.com/charts/loader.js", {
+            success: () => {
+              const google_charts = getGoogleCharts(window);
+              loadGCharts(google_charts);
+              google_charts.setOnLoadCallback(() => {
+                this.isLoaded = true;
+                this.isLoading = false;
+                resolve();
+              });
+            }
+          });
+        }
       });
       this.isLoading = true;
       return this.loadScript;


### PR DESCRIPTION
This pull request fixes issues #202 and #204 related to the "Error: Google Charts loader.js can only be loaded once" error appearing when dismounting and mounting the component again, when switching pages for example. 

The problem is that when the component is mounted, the google chart script was always loaded. Adding checks on the loader to only load the google chart library if it has not already been loaded (if the window.google.chart global is not present), fixes the issue.

