### PR TITLE
Export Google charts loader

### DIFF
--- a/demo/index-interactive.html
+++ b/demo/index-interactive.html
@@ -1,0 +1,22 @@
+<html>
+
+<head>
+</head>
+
+<body>
+  <div>
+    <div>Google charts should be available at this point.</div>
+    <div>To render the demo charts, click the button below.</div>
+    <div>To see that Google charts are available, check these in your browser's console:
+      <pre>
+        <code>console.log(google.charts)</code>
+        <code>console.log(google.visualization)</code>
+      </pre>
+    </div>
+  </div>
+  <div id="app">
+  </div>
+  <script src="./index-interactive.js" />
+</body>
+
+</html>

--- a/demo/index-interactive.js
+++ b/demo/index-interactive.js
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { Chart, googleChartLoader } from '../src/index';
+
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { renderCharts: false };
+    this.toggleCharts = this.toggleCharts.bind(this);
+  }
+
+  data() {
+    return [['Age', 'Avg. Weight'], [70, 183], [55, 192], [40, 175], [20, 150], [8, 12], [4, 5.5]];
+  }
+
+  toggleCharts() {
+    this.setState({ renderCharts: !this.state.renderCharts });
+  }
+
+  render() {
+    googleChartLoader
+      .init({
+        chartPackages: Chart.defaultProps.chartPackages,
+        chartVersion: Chart.defaultProps.chartVersion,
+        chartLanguage: Chart.defaultProps.chartLanguage,
+      })
+      .then(() => {});
+    return (
+      <div>
+        <div>
+          <button onClick={this.toggleCharts}>Toggle Charts</button>
+        </div>
+        {this.state.renderCharts && (
+          <div style={{ margin: 'auto', padding: '0px 5%', display: 'flex', flex: 'auto', flexFlow: 'row wrap' }}>
+            <Chart
+              chartType="LineChart"
+              data={this.data()}
+              options={{}}
+              graph_id="LineChart"
+              width="33%"
+              height="400px"
+              legend_toggle
+            />
+            <Chart
+              chartType="ScatterChart"
+              data={this.data()}
+              options={{ colors: ['salmon'] }}
+              graph_id="ScatterChart"
+              width="33%"
+              height="400px"
+              legend_toggle
+            />
+            <Chart
+              chartType="ColumnChart"
+              data={this.data()}
+              options={{ colors: ['limegreen'] }}
+              graph_id="ColumnChart"
+              width="33%"
+              height="400px"
+              legend_toggle
+            />
+            <Chart
+              chartType="BarChart"
+              data={this.data()}
+              options={{ colors: ['orange'] }}
+              graph_id="BarChart"
+              width="33%"
+              height="400px"
+              legend_toggle
+            />
+            <Chart
+              chartType="AreaChart"
+              data={this.data()}
+              options={{ colors: ['violet'] }}
+              graph_id="AreaChart"
+              width="33%"
+              height="400px"
+              legend_toggle
+            />
+            <Chart
+              chartType="Table"
+              data={this.data()}
+              options={{ showRowNumber: false, width: '100%', height: '100%' }}
+              graph_id="Table"
+              width="33%"
+              height="400px"
+              legend_toggle
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "build/index.js",
   "scripts": {
     "start": "parcel demo/index.html",
+    "start-interactive": "parcel demo/index-interactive.html",
     "build": "microbundle"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,48 +1,48 @@
-import { Component, createElement } from 'react';
+import { Component, createElement } from "react";
 
 const DEFAULT_CHART_COLORS = [
-  '#3366CC',
-  '#DC3912',
-  '#FF9900',
-  '#109618',
-  '#990099',
-  '#3B3EAC',
-  '#0099C6',
-  '#DD4477',
-  '#66AA00',
-  '#B82E2E',
-  '#316395',
-  '#994499',
-  '#22AA99',
-  '#AAAA11',
-  '#6633CC',
-  '#E67300',
-  '#8B0707',
-  '#329262',
-  '#5574A6',
-  '#3B3EAC',
+  "#3366CC",
+  "#DC3912",
+  "#FF9900",
+  "#109618",
+  "#990099",
+  "#3B3EAC",
+  "#0099C6",
+  "#DD4477",
+  "#66AA00",
+  "#B82E2E",
+  "#316395",
+  "#994499",
+  "#22AA99",
+  "#AAAA11",
+  "#6633CC",
+  "#E67300",
+  "#8B0707",
+  "#329262",
+  "#5574A6",
+  "#3B3EAC"
 ];
 
 var DEFAULT_COLORS = /*#__PURE__*/ Object.freeze({
   DEFAULT_CHART_COLORS: DEFAULT_CHART_COLORS,
-  default: DEFAULT_CHART_COLORS,
+  default: DEFAULT_CHART_COLORS
 });
 
 const getGoogle = (windowAsArg = window) => {
-  if (typeof windowAsArg === 'undefined') {
+  if (typeof windowAsArg === "undefined") {
     return {};
   }
-  if (typeof windowAsArg.google === 'undefined') {
-    throw new Error('google not in window object. Error in get-google-charts.');
+  if (typeof windowAsArg.google === "undefined") {
+    throw new Error("google not in window object. Error in get-google-charts.");
   }
   return windowAsArg.google;
 };
 const getGoogleCharts = (windowAsArg = window) => {
-  if (typeof windowAsArg === 'undefined') {
+  if (typeof windowAsArg === "undefined") {
     return {};
   }
-  if (typeof windowAsArg.google === 'undefined') {
-    throw new Error('google not in window object. Error in get-google-charts.');
+  if (typeof windowAsArg.google === "undefined") {
+    throw new Error("google not in window object. Error in get-google-charts.");
   }
   return windowAsArg.google.charts;
 };
@@ -62,22 +62,25 @@ class GoogleChartLoader {
         return this.loadScript;
       }
       this.isLoading = true;
-      const script = typeof window !== 'undefined' ? require('loadjs') : (link, { success: callback }) => callback();
+      const script =
+        typeof window !== "undefined"
+          ? require("loadjs")
+          : (link, { success: callback }) => callback();
       this.loadScript = new Promise(resolve => {
-        script('https://www.gstatic.com/charts/loader.js', {
+        script("https://www.gstatic.com/charts/loader.js", {
           success: () => {
             const google_charts = getGoogleCharts(window);
-            google_charts.load(version || 'current', {
-              packages: packages || ['corechart'],
-              language: language || 'en',
-              mapsApiKey,
+            google_charts.load(version || "current", {
+              packages: packages || ["corechart"],
+              language: language || "en",
+              mapsApiKey
             });
             google_charts.setOnLoadCallback(() => {
               this.isLoaded = true;
               this.isLoading = false;
               resolve();
             });
-          },
+          }
         });
       });
       this.isLoading = true;
@@ -128,7 +131,9 @@ class Chart extends Component {
     };
     this.applyNumberFormat = (column, options) => {
       const googlefromWindow = getGoogle(window);
-      const formatter = new googlefromWindow.visualization.NumberFormat(options);
+      const formatter = new googlefromWindow.visualization.NumberFormat(
+        options
+      );
       formatter.format(this.dataTable, column);
     };
     this.applyDateFormat = (column, options) => {
@@ -141,9 +146,14 @@ class Chart extends Component {
       const googlefromWindow = getGoogle(window);
       if (this.props.diffdata && this.props.chartType !== null) {
         const diffdata = this.props.diffdata;
-        const oldData = googlefromWindow.visualization.arrayToDataTable(diffdata.old);
-        const newData = googlefromWindow.visualization.arrayToDataTable(diffdata.new);
-        const computeDiff = googlefromWindow.visualization[chartType].prototype.computeDiff;
+        const oldData = googlefromWindow.visualization.arrayToDataTable(
+          diffdata.old
+        );
+        const newData = googlefromWindow.visualization.arrayToDataTable(
+          diffdata.new
+        );
+        const computeDiff =
+          googlefromWindow.visualization[chartType].prototype.computeDiff;
         const chartDiff = computeDiff(oldData, newData);
         return chartDiff;
       }
@@ -152,9 +162,16 @@ class Chart extends Component {
         (this.props.rows && this.props.rows.length === 0) &&
         !this.props.allowEmptyRows === false
       ) {
-        throw new Error("Can't build DataTable from rows and columns: rows array in props is empty");
-      } else if (this.props.data === null && (this.props.columns && this.props.columns.length === 0)) {
-        throw new Error("Can't build DataTable from rows and columns: columns array in props is empty");
+        throw new Error(
+          "Can't build DataTable from rows and columns: rows array in props is empty"
+        );
+      } else if (
+        this.props.data === null &&
+        (this.props.columns && this.props.columns.length === 0)
+      ) {
+        throw new Error(
+          "Can't build DataTable from rows and columns: columns array in props is empty"
+        );
       }
       if (this.props.data !== null) {
         try {
@@ -162,7 +179,7 @@ class Chart extends Component {
           const dataTable = this.wrapper.getDataTable();
           return dataTable;
         } catch (err) {
-          throw new Error('Failed to set DataTable from data props ! ', err);
+          throw new Error("Failed to set DataTable from data props ! ", err);
         }
       }
       const dataTable = new window.google.visualization.DataTable();
@@ -182,10 +199,10 @@ class Chart extends Component {
       }
       this.props.formatters.forEach(({ type, column, options }) => {
         switch (type) {
-          case 'NumberFormat':
+          case "NumberFormat":
             this.applyNumberFormat(column, options);
             break;
-          case 'DateFormat':
+          case "DateFormat":
             this.applyDateFormat(column, options);
             break;
           default:
@@ -196,7 +213,9 @@ class Chart extends Component {
       return dataTable;
     };
     this.updateDataTable = () => {
-      window.google.visualization.errors.removeAll(document.getElementById(this.wrapper.getContainerId()));
+      window.google.visualization.errors.removeAll(
+        document.getElementById(this.wrapper.getContainerId())
+      );
       this.dataTable.removeRows(0, this.dataTable.getNumberOfRows());
       this.dataTable.removeColumns(0, this.dataTable.getNumberOfColumns());
       this.dataTable = this.buildDataTableFromProps();
@@ -210,16 +229,22 @@ class Chart extends Component {
         const chartConfig = {
           chartType: this.props.chartType,
           options: this.props.options,
-          containerId: this.state.graphID,
+          containerId: this.state.graphID
         };
-        this.wrapper = new window.google.visualization.ChartWrapper(chartConfig);
+        this.wrapper = new window.google.visualization.ChartWrapper(
+          chartConfig
+        );
         this.dataTable = this.buildDataTableFromProps();
         this.wrapper.setDataTable(this.dataTable);
-        window.google.visualization.events.addOneTimeListener(this.wrapper, 'ready', () => {
-          this.chart = this.wrapper.getChart();
-          this.listenToChartEvents();
-          this.addChartActions();
-        });
+        window.google.visualization.events.addOneTimeListener(
+          this.wrapper,
+          "ready",
+          () => {
+            this.chart = this.wrapper.getChart();
+            this.listenToChartEvents();
+            this.addChartActions();
+          }
+        );
       } else {
         this.updateDataTable();
         this.wrapper.setDataTable(this.dataTable);
@@ -228,10 +253,14 @@ class Chart extends Component {
           window.google.visualization.events.removeAllListeners(this.wrapper);
           this.wrapper.setChartType(this.props.chartType);
           const self = this;
-          window.google.visualization.events.addOneTimeListener(this.wrapper, 'ready', () => {
-            self.chart = self.wrapper.getChart();
-            self.listenToChartEvents.call(self);
-          });
+          window.google.visualization.events.addOneTimeListener(
+            this.wrapper,
+            "ready",
+            () => {
+              self.chart = self.wrapper.getChart();
+              self.listenToChartEvents.call(self);
+            }
+          );
         }
       }
       this.wrapper.draw();
@@ -244,22 +273,30 @@ class Chart extends Component {
         this.chart.setAction({
           id: chartAction.id,
           text: chartAction.text,
-          action: chartAction.action.bind(this, this.chart),
+          action: chartAction.action.bind(this, this.chart)
         });
       });
     };
     this.listenToChartEvents = () => {
       if (this.props.legend_toggle) {
-        window.google.visualization.events.addListener(this.wrapper, 'select', this.onSelectToggle);
+        window.google.visualization.events.addListener(
+          this.wrapper,
+          "select",
+          this.onSelectToggle
+        );
       }
       this.props.chartEvents.forEach(chartEvent => {
-        if (chartEvent.eventName === 'ready') {
+        if (chartEvent.eventName === "ready") {
           chartEvent.callback(this);
         } else {
           (event => {
-            window.google.visualization.events.addListener(this.chart, event.eventName, e => {
-              event.callback(this, e);
-            });
+            window.google.visualization.events.addListener(
+              this.chart,
+              event.eventName,
+              e => {
+                event.callback(this, e);
+              }
+            );
           })(chartEvent);
         }
       });
@@ -269,7 +306,7 @@ class Chart extends Component {
         label: this.dataTable.getColumnLabel(columnIndex),
         type: this.dataTable.getColumnType(columnIndex),
         sourceColumn: columnIndex,
-        role: this.dataTable.getColumnRole(columnIndex),
+        role: this.dataTable.getColumnRole(columnIndex)
       };
     };
     this.buildEmptyColumnFromSourceData = columnIndex => {
@@ -277,7 +314,7 @@ class Chart extends Component {
         label: this.dataTable.getColumnLabel(columnIndex),
         type: this.dataTable.getColumnType(columnIndex),
         calc: () => null,
-        role: this.dataTable.getColumnRole(columnIndex),
+        role: this.dataTable.getColumnRole(columnIndex)
       };
     };
     this.addEmptyColumnTo = (columns, columnIndex) => {
@@ -287,10 +324,10 @@ class Chart extends Component {
     this.hideColumn = (colors, columnIndex) => {
       if (!this.isHidden(columnIndex)) {
         this.hidden_columns[columnIndex] = {
-          color: this.getColumnColor(columnIndex - 1),
+          color: this.getColumnColor(columnIndex - 1)
         };
       }
-      colors.push('#CCCCCC');
+      colors.push("#CCCCCC");
     };
     this.addSourceColumnTo = (columns, columnIndex) => {
       const sourceColumn = this.buildColumnFromSourceData(columnIndex);
@@ -320,7 +357,9 @@ class Chart extends Component {
       };
     };
     this.togglePoints = column => {
-      const view = new window.google.visualization.DataView(this.wrapper.getDataTable());
+      const view = new window.google.visualization.DataView(
+        this.wrapper.getDataTable()
+      );
       const columnCount = view.getNumberOfColumns();
       let colors = [];
       let columns = [];
@@ -350,16 +389,21 @@ class Chart extends Component {
     this.state = { graphID: props.graph_id || generateUniqueID() };
   }
   componentDidMount() {
-    if (typeof window === 'undefined') {
+    if (typeof window === "undefined") {
       return;
     }
     if (this.props.loadCharts) {
       googleChartLoader
-        .init(this.props.chartPackages, this.props.chartVersion, this.props.chartLanguage, this.props.mapsApiKey)
+        .init(
+          this.props.chartPackages,
+          this.props.chartVersion,
+          this.props.chartLanguage,
+          this.props.mapsApiKey
+        )
         .then(() => {
           this.drawChart();
           this.onResize = this.debounce(this.onResize, 200);
-          window.addEventListener('resize', this.onResize);
+          window.addEventListener("resize", this.onResize);
         });
     } else {
       this.drawChart();
@@ -385,7 +429,7 @@ class Chart extends Component {
         if (window.google && window.google.visualization) {
           window.google.visualization.events.removeAllListeners(this.wrapper);
         }
-        window.removeEventListener('resize', this.onResize);
+        window.removeEventListener("resize", this.onResize);
       }
     } catch (err) {
       return;
@@ -394,45 +438,45 @@ class Chart extends Component {
   render() {
     const divStyle = {
       height: this.props.height || this.props.options.height,
-      width: this.props.width || this.props.options.width,
+      width: this.props.width || this.props.options.width
     };
     return createElement(
-      'div',
+      "div",
       { id: this.state.graphID, style: divStyle },
-      this.props.loader ? this.props.loader : 'Rendering Chart...'
+      this.props.loader ? this.props.loader : "Rendering Chart..."
     );
   }
 }
 Chart.defaultProps = {
-  chartType: 'LineChart',
+  chartType: "LineChart",
   rows: [],
   columns: [],
   options: {
     chart: {
-      title: 'Chart Title',
-      subtitle: 'Subtitle',
+      title: "Chart Title",
+      subtitle: "Subtitle"
     },
-    hAxis: { title: 'X Label' },
-    vAxis: { title: 'Y Label' },
-    width: '100%',
-    height: '100%',
+    hAxis: { title: "X Label" },
+    vAxis: { title: "Y Label" },
+    width: "100%",
+    height: "100%"
   },
-  width: '400px',
-  height: '300px',
+  width: "400px",
+  height: "300px",
   chartEvents: [],
   chartActions: null,
   data: null,
   legend_toggle: false,
   allowEmptyRows: false,
   loadCharts: true,
-  loader: createElement('div', null, 'Rendering Chart'),
-  chartPackages: ['corechart'],
-  chartVersion: 'current',
-  chartLanguage: 'en',
+  loader: createElement("div", null, "Rendering Chart"),
+  chartPackages: ["corechart"],
+  chartVersion: "current",
+  chartLanguage: "en",
   numberFormat: null,
   dateFormat: null,
   formatters: [],
-  diffdata: null,
+  diffdata: null
 };
 
 var index = { Chart };

--- a/src/index.js
+++ b/src/index.js
@@ -1,48 +1,48 @@
-import { Component, createElement } from "react";
+import { Component, createElement } from 'react';
 
 const DEFAULT_CHART_COLORS = [
-  "#3366CC",
-  "#DC3912",
-  "#FF9900",
-  "#109618",
-  "#990099",
-  "#3B3EAC",
-  "#0099C6",
-  "#DD4477",
-  "#66AA00",
-  "#B82E2E",
-  "#316395",
-  "#994499",
-  "#22AA99",
-  "#AAAA11",
-  "#6633CC",
-  "#E67300",
-  "#8B0707",
-  "#329262",
-  "#5574A6",
-  "#3B3EAC"
+  '#3366CC',
+  '#DC3912',
+  '#FF9900',
+  '#109618',
+  '#990099',
+  '#3B3EAC',
+  '#0099C6',
+  '#DD4477',
+  '#66AA00',
+  '#B82E2E',
+  '#316395',
+  '#994499',
+  '#22AA99',
+  '#AAAA11',
+  '#6633CC',
+  '#E67300',
+  '#8B0707',
+  '#329262',
+  '#5574A6',
+  '#3B3EAC',
 ];
 
 var DEFAULT_COLORS = /*#__PURE__*/ Object.freeze({
   DEFAULT_CHART_COLORS: DEFAULT_CHART_COLORS,
-  default: DEFAULT_CHART_COLORS
+  default: DEFAULT_CHART_COLORS,
 });
 
 const getGoogle = (windowAsArg = window) => {
-  if (typeof windowAsArg === "undefined") {
+  if (typeof windowAsArg === 'undefined') {
     return {};
   }
-  if (typeof windowAsArg.google === "undefined") {
-    throw new Error("google not in window object. Error in get-google-charts.");
+  if (typeof windowAsArg.google === 'undefined') {
+    throw new Error('google not in window object. Error in get-google-charts.');
   }
   return windowAsArg.google;
 };
 const getGoogleCharts = (windowAsArg = window) => {
-  if (typeof windowAsArg === "undefined") {
+  if (typeof windowAsArg === 'undefined') {
     return {};
   }
-  if (typeof windowAsArg.google === "undefined") {
-    throw new Error("google not in window object. Error in get-google-charts.");
+  if (typeof windowAsArg.google === 'undefined') {
+    throw new Error('google not in window object. Error in get-google-charts.');
   }
   return windowAsArg.google.charts;
 };
@@ -62,25 +62,22 @@ class GoogleChartLoader {
         return this.loadScript;
       }
       this.isLoading = true;
-      const script =
-        typeof window !== "undefined"
-          ? require("loadjs")
-          : (link, { success: callback }) => callback();
+      const script = typeof window !== 'undefined' ? require('loadjs') : (link, { success: callback }) => callback();
       this.loadScript = new Promise(resolve => {
-        script("https://www.gstatic.com/charts/loader.js", {
+        script('https://www.gstatic.com/charts/loader.js', {
           success: () => {
             const google_charts = getGoogleCharts(window);
-            google_charts.load(version || "current", {
-              packages: packages || ["corechart"],
-              language: language || "en",
-              mapsApiKey
+            google_charts.load(version || 'current', {
+              packages: packages || ['corechart'],
+              language: language || 'en',
+              mapsApiKey,
             });
             google_charts.setOnLoadCallback(() => {
               this.isLoaded = true;
               this.isLoading = false;
               resolve();
             });
-          }
+          },
         });
       });
       this.isLoading = true;
@@ -131,9 +128,7 @@ class Chart extends Component {
     };
     this.applyNumberFormat = (column, options) => {
       const googlefromWindow = getGoogle(window);
-      const formatter = new googlefromWindow.visualization.NumberFormat(
-        options
-      );
+      const formatter = new googlefromWindow.visualization.NumberFormat(options);
       formatter.format(this.dataTable, column);
     };
     this.applyDateFormat = (column, options) => {
@@ -146,14 +141,9 @@ class Chart extends Component {
       const googlefromWindow = getGoogle(window);
       if (this.props.diffdata && this.props.chartType !== null) {
         const diffdata = this.props.diffdata;
-        const oldData = googlefromWindow.visualization.arrayToDataTable(
-          diffdata.old
-        );
-        const newData = googlefromWindow.visualization.arrayToDataTable(
-          diffdata.new
-        );
-        const computeDiff =
-          googlefromWindow.visualization[chartType].prototype.computeDiff;
+        const oldData = googlefromWindow.visualization.arrayToDataTable(diffdata.old);
+        const newData = googlefromWindow.visualization.arrayToDataTable(diffdata.new);
+        const computeDiff = googlefromWindow.visualization[chartType].prototype.computeDiff;
         const chartDiff = computeDiff(oldData, newData);
         return chartDiff;
       }
@@ -162,16 +152,9 @@ class Chart extends Component {
         (this.props.rows && this.props.rows.length === 0) &&
         !this.props.allowEmptyRows === false
       ) {
-        throw new Error(
-          "Can't build DataTable from rows and columns: rows array in props is empty"
-        );
-      } else if (
-        this.props.data === null &&
-        (this.props.columns && this.props.columns.length === 0)
-      ) {
-        throw new Error(
-          "Can't build DataTable from rows and columns: columns array in props is empty"
-        );
+        throw new Error("Can't build DataTable from rows and columns: rows array in props is empty");
+      } else if (this.props.data === null && (this.props.columns && this.props.columns.length === 0)) {
+        throw new Error("Can't build DataTable from rows and columns: columns array in props is empty");
       }
       if (this.props.data !== null) {
         try {
@@ -179,7 +162,7 @@ class Chart extends Component {
           const dataTable = this.wrapper.getDataTable();
           return dataTable;
         } catch (err) {
-          throw new Error("Failed to set DataTable from data props ! ", err);
+          throw new Error('Failed to set DataTable from data props ! ', err);
         }
       }
       const dataTable = new window.google.visualization.DataTable();
@@ -199,10 +182,10 @@ class Chart extends Component {
       }
       this.props.formatters.forEach(({ type, column, options }) => {
         switch (type) {
-          case "NumberFormat":
+          case 'NumberFormat':
             this.applyNumberFormat(column, options);
             break;
-          case "DateFormat":
+          case 'DateFormat':
             this.applyDateFormat(column, options);
             break;
           default:
@@ -213,9 +196,7 @@ class Chart extends Component {
       return dataTable;
     };
     this.updateDataTable = () => {
-      window.google.visualization.errors.removeAll(
-        document.getElementById(this.wrapper.getContainerId())
-      );
+      window.google.visualization.errors.removeAll(document.getElementById(this.wrapper.getContainerId()));
       this.dataTable.removeRows(0, this.dataTable.getNumberOfRows());
       this.dataTable.removeColumns(0, this.dataTable.getNumberOfColumns());
       this.dataTable = this.buildDataTableFromProps();
@@ -229,22 +210,16 @@ class Chart extends Component {
         const chartConfig = {
           chartType: this.props.chartType,
           options: this.props.options,
-          containerId: this.state.graphID
+          containerId: this.state.graphID,
         };
-        this.wrapper = new window.google.visualization.ChartWrapper(
-          chartConfig
-        );
+        this.wrapper = new window.google.visualization.ChartWrapper(chartConfig);
         this.dataTable = this.buildDataTableFromProps();
         this.wrapper.setDataTable(this.dataTable);
-        window.google.visualization.events.addOneTimeListener(
-          this.wrapper,
-          "ready",
-          () => {
-            this.chart = this.wrapper.getChart();
-            this.listenToChartEvents();
-            this.addChartActions();
-          }
-        );
+        window.google.visualization.events.addOneTimeListener(this.wrapper, 'ready', () => {
+          this.chart = this.wrapper.getChart();
+          this.listenToChartEvents();
+          this.addChartActions();
+        });
       } else {
         this.updateDataTable();
         this.wrapper.setDataTable(this.dataTable);
@@ -253,14 +228,10 @@ class Chart extends Component {
           window.google.visualization.events.removeAllListeners(this.wrapper);
           this.wrapper.setChartType(this.props.chartType);
           const self = this;
-          window.google.visualization.events.addOneTimeListener(
-            this.wrapper,
-            "ready",
-            () => {
-              self.chart = self.wrapper.getChart();
-              self.listenToChartEvents.call(self);
-            }
-          );
+          window.google.visualization.events.addOneTimeListener(this.wrapper, 'ready', () => {
+            self.chart = self.wrapper.getChart();
+            self.listenToChartEvents.call(self);
+          });
         }
       }
       this.wrapper.draw();
@@ -273,30 +244,22 @@ class Chart extends Component {
         this.chart.setAction({
           id: chartAction.id,
           text: chartAction.text,
-          action: chartAction.action.bind(this, this.chart)
+          action: chartAction.action.bind(this, this.chart),
         });
       });
     };
     this.listenToChartEvents = () => {
       if (this.props.legend_toggle) {
-        window.google.visualization.events.addListener(
-          this.wrapper,
-          "select",
-          this.onSelectToggle
-        );
+        window.google.visualization.events.addListener(this.wrapper, 'select', this.onSelectToggle);
       }
       this.props.chartEvents.forEach(chartEvent => {
-        if (chartEvent.eventName === "ready") {
+        if (chartEvent.eventName === 'ready') {
           chartEvent.callback(this);
         } else {
           (event => {
-            window.google.visualization.events.addListener(
-              this.chart,
-              event.eventName,
-              e => {
-                event.callback(this, e);
-              }
-            );
+            window.google.visualization.events.addListener(this.chart, event.eventName, e => {
+              event.callback(this, e);
+            });
           })(chartEvent);
         }
       });
@@ -306,7 +269,7 @@ class Chart extends Component {
         label: this.dataTable.getColumnLabel(columnIndex),
         type: this.dataTable.getColumnType(columnIndex),
         sourceColumn: columnIndex,
-        role: this.dataTable.getColumnRole(columnIndex)
+        role: this.dataTable.getColumnRole(columnIndex),
       };
     };
     this.buildEmptyColumnFromSourceData = columnIndex => {
@@ -314,7 +277,7 @@ class Chart extends Component {
         label: this.dataTable.getColumnLabel(columnIndex),
         type: this.dataTable.getColumnType(columnIndex),
         calc: () => null,
-        role: this.dataTable.getColumnRole(columnIndex)
+        role: this.dataTable.getColumnRole(columnIndex),
       };
     };
     this.addEmptyColumnTo = (columns, columnIndex) => {
@@ -324,10 +287,10 @@ class Chart extends Component {
     this.hideColumn = (colors, columnIndex) => {
       if (!this.isHidden(columnIndex)) {
         this.hidden_columns[columnIndex] = {
-          color: this.getColumnColor(columnIndex - 1)
+          color: this.getColumnColor(columnIndex - 1),
         };
       }
-      colors.push("#CCCCCC");
+      colors.push('#CCCCCC');
     };
     this.addSourceColumnTo = (columns, columnIndex) => {
       const sourceColumn = this.buildColumnFromSourceData(columnIndex);
@@ -357,9 +320,7 @@ class Chart extends Component {
       };
     };
     this.togglePoints = column => {
-      const view = new window.google.visualization.DataView(
-        this.wrapper.getDataTable()
-      );
+      const view = new window.google.visualization.DataView(this.wrapper.getDataTable());
       const columnCount = view.getNumberOfColumns();
       let colors = [];
       let columns = [];
@@ -389,21 +350,16 @@ class Chart extends Component {
     this.state = { graphID: props.graph_id || generateUniqueID() };
   }
   componentDidMount() {
-    if (typeof window === "undefined") {
+    if (typeof window === 'undefined') {
       return;
     }
     if (this.props.loadCharts) {
       googleChartLoader
-        .init(
-          this.props.chartPackages,
-          this.props.chartVersion,
-          this.props.chartLanguage,
-          this.props.mapsApiKey
-        )
+        .init(this.props.chartPackages, this.props.chartVersion, this.props.chartLanguage, this.props.mapsApiKey)
         .then(() => {
           this.drawChart();
           this.onResize = this.debounce(this.onResize, 200);
-          window.addEventListener("resize", this.onResize);
+          window.addEventListener('resize', this.onResize);
         });
     } else {
       this.drawChart();
@@ -429,7 +385,7 @@ class Chart extends Component {
         if (window.google && window.google.visualization) {
           window.google.visualization.events.removeAllListeners(this.wrapper);
         }
-        window.removeEventListener("resize", this.onResize);
+        window.removeEventListener('resize', this.onResize);
       }
     } catch (err) {
       return;
@@ -438,48 +394,48 @@ class Chart extends Component {
   render() {
     const divStyle = {
       height: this.props.height || this.props.options.height,
-      width: this.props.width || this.props.options.width
+      width: this.props.width || this.props.options.width,
     };
     return createElement(
-      "div",
+      'div',
       { id: this.state.graphID, style: divStyle },
-      this.props.loader ? this.props.loader : "Rendering Chart..."
+      this.props.loader ? this.props.loader : 'Rendering Chart...'
     );
   }
 }
 Chart.defaultProps = {
-  chartType: "LineChart",
+  chartType: 'LineChart',
   rows: [],
   columns: [],
   options: {
     chart: {
-      title: "Chart Title",
-      subtitle: "Subtitle"
+      title: 'Chart Title',
+      subtitle: 'Subtitle',
     },
-    hAxis: { title: "X Label" },
-    vAxis: { title: "Y Label" },
-    width: "100%",
-    height: "100%"
+    hAxis: { title: 'X Label' },
+    vAxis: { title: 'Y Label' },
+    width: '100%',
+    height: '100%',
   },
-  width: "400px",
-  height: "300px",
+  width: '400px',
+  height: '300px',
   chartEvents: [],
   chartActions: null,
   data: null,
   legend_toggle: false,
   allowEmptyRows: false,
   loadCharts: true,
-  loader: createElement("div", null, "Rendering Chart"),
-  chartPackages: ["corechart"],
-  chartVersion: "current",
-  chartLanguage: "en",
+  loader: createElement('div', null, 'Rendering Chart'),
+  chartPackages: ['corechart'],
+  chartVersion: 'current',
+  chartLanguage: 'en',
   numberFormat: null,
   dateFormat: null,
   formatters: [],
-  diffdata: null
+  diffdata: null,
 };
 
 var index = { Chart };
 
 export default index;
-export { Chart };
+export { Chart, googleChartLoader };


### PR DESCRIPTION
Some applications that use this library will want to load the Google charts library before rendering any charts (for instance, so that Google charts get loaded only once in a single-page application). This change exports the Google charts loader and allows it to be initialized before any chart rendering happens.

This PR also adds a new interactive demo that exercises the exported function.

### The new demo page before the charts are rendered
![image](https://user-images.githubusercontent.com/7836/42393831-d2d9513a-8125-11e8-8994-947e081b43f4.png)

### The new demo page after the charts have been rendered
![image](https://user-images.githubusercontent.com/7836/42393866-033f7818-8126-11e8-89ec-e31017725432.png)
