### PR TITLE
fix(Types):Update Chart Type for TableChart in Typescript

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -89,7 +89,7 @@ export type GoogleChartWrapperChartType =
   | "Sankey"
   | "ScatterChart"
   | "SteppedAreaChart"
-  | "TableChart"
+  | "Table"
   | "Timeline"
   | "TreeMap"
   | "WaterfallChart"


### PR DESCRIPTION
Branching off Microsoft's [React-Typescript-Starter](https://github.com/Microsoft/TypeScript-React-Starter), I found that using the Table chart with the currently implemented 'TableChart' chartType prop would cause the app to fail to compile. 

This pull request simply updates TableChart to Table in the 'GoogleChartWrapperChartType' union type.