### PR TITLE
[TS] Add prop type for Line - Material Charts 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,7 @@ export type GoogleChartWrapperChartType =
   | "GeoChart"
   | "Histogram"
   | "LineChart"
+  | "Line"
   | "Map"
   | "OrgChart"
   | "PieChart"


### PR DESCRIPTION
TS2322: Type '"Line"' is not assignable to type 'GoogleChartWrapperChartType'.

To suppress this error 