### PR TITLE
Clear chart before unmount

### DIFF
--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -104,7 +104,12 @@ const Issue317 = () => {
   );
 };
 
-class InteractiveChart extends React.Component<{}, { data: any[][] }> {
+type State = {
+  data: any[][];
+  isOrphansDemoVisible: boolean;
+}
+
+class InteractiveChart extends React.Component<{}, State> {
   constructor(props) {
     super(props);
     this.state = {
@@ -127,7 +132,8 @@ class InteractiveChart extends React.Component<{}, { data: any[][] }> {
         [4, 5.5, 1],
         [8, 12, 2],
         [11, 14, 3]
-      ]
+      ],
+      isOrphansDemoVisible: true
     };
   }
 
@@ -211,6 +217,24 @@ class InteractiveChart extends React.Component<{}, { data: any[][] }> {
           height="400px"
           legendToggle
         />
+
+        <button type="button" onClick={() => this.setState({isOrphansDemoVisible: !this.state.isOrphansDemoVisible})}>
+          Toggle orphans demo
+        </button>
+        {this.state.isOrphansDemoVisible && (
+          <Chart
+            chartType="LineChart"
+            data={[
+              ["x", "Very long label 111111111111111111111111", "cats"],
+              [0, 0, 0],
+              [1, 23, 15],
+              [2, 10, 5],
+            ]}
+            options={{ explorer: {}}}
+            width="100%"
+            height="400px"
+          />
+        )}
       </div>
     );
   }

--- a/src/components/GoogleChart.tsx
+++ b/src/components/GoogleChart.tsx
@@ -212,6 +212,15 @@ export class GoogleChart extends React.Component<Props, State> {
       this.state.googleChartControls[i].control.setControlType(controlType);
     }
   }
+  componentWillUnmount() {
+    const {googleChartWrapper} = this.state;
+    if (googleChartWrapper) {
+      const chart = googleChartWrapper.getChart();
+      if (chart && chart.clearChart) {
+        chart.clearChart();
+      }
+    }
+  }
   shouldComponentUpdate(nextProps: Props, nextState: State) {
     return (
       this.state.isReady !== nextState.isReady ||


### PR DESCRIPTION
**Problem**
Google Chart creates a lot of nodes in the body for elements in the legend, that should be truncated with ellipsis. https://github.com/google/google-visualization-issues/issues/2822
Later these nodes will be used as a tooltip when user hover over a truncated element.

When component is unmounted, these **orphan nodes are left in the body**, which leads to memory leak and worse DOM performance because of a lot of elements in it. This is especially true in SPAs, when you might have one page with google charts which might affect the rest of the
pages if you don't remove orphan nodes manually.
Even worse, that when you use legend pagination feature or zoom in chart, old nodes are not being removed. If you zoom in and out multiple times, you easily could be ended up with thousands of orphan nodes in the body.

**Fix**
Call `clearChart` on unmount. I'm not sure how correct typings are in its current state. For example `getChart()` can return null, and I'm not sure if all charts have `clearChart` method. That is why I added these checks, even though TS allows to omit them.

**Test**
To test this change you can check that there is a single node, created in the body for "Very long label...". When you click "Toggle orphans demo", this node will be removed.

I failed to run e2e tests for some reason, but it could be possible to check that orphan nodes are removed from the body when chart unmounts.
