### PR TITLE
Make getChart result nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ const chartEvents = [
   {
     eventName: "select",
     callback({ chartWrapper }) {
-      console.log("Selected ", chartWrapper.getChart().getSelection());
+      const chart = chartWrapper.getChart();
+      if (chart) {
+        console.log("Selected ", chart.getSelection());
+      }
     }
   }
 ];

--- a/src/components/GoogleChartActions.tsx
+++ b/src/components/GoogleChartActions.tsx
@@ -37,7 +37,10 @@ export class GoogleChartActionsInner extends React.Component<Props> {
   ) => {
     const { googleChartWrapper } = this.props;
     if (googleChartWrapper === null) return;
+
     const chart = googleChartWrapper.getChart();
+    if (chart === null) return;
+
     for (let chartAction of previousActions) {
       chart.removeAction(chartAction.id);
     }

--- a/src/components/GoogleChartDataTable.tsx
+++ b/src/components/GoogleChartDataTable.tsx
@@ -40,6 +40,10 @@ export class GoogleChartDataTableInner extends React.Component<
       "select",
       () => {
         const chart = googleChartWrapper.getChart();
+        if (!chart) {
+          return;
+        }
+
         const selection = chart.getSelection();
         const dataTable = googleChartWrapper.getDataTable();
         if (
@@ -259,8 +263,8 @@ export class GoogleChartDataTableInner extends React.Component<
     window.removeEventListener("resize", this.onResize);
     google.visualization.events.removeAllListeners(googleChartWrapper);
     if (googleChartWrapper.getChartType() === "Timeline") {
-      googleChartWrapper.getChart() &&
-        googleChartWrapper.getChart().clearChart();
+      const chart = googleChartWrapper.getChart();
+      chart && chart.clearChart();
     }
   }
 

--- a/src/docs/Interactions/ReactToUserSelection.mdx
+++ b/src/docs/Interactions/ReactToUserSelection.mdx
@@ -1,6 +1,6 @@
 ---
 route: /user-selection
-name: Interactions 
+name: Interactions
 ---
 
 
@@ -10,12 +10,15 @@ import Chart from '../../index'
 ## Simple example
 
 <Playground>
-  <Chart 
+  <Chart
     chartType="ScatterChart"
     data={[['x', 'dogs'], [0, 0],   [1, 10],  [2, 23],  [3, 17],  [4, 18],  [5, 9]]}
     chartEvents={[
       {eventName: 'select', callback: ({chartWrapper}) => {
         const chart = chartWrapper.getChart();
+        if (!chart) {
+          return;
+        }
         const selection = chart.getSelection();
         if (selection.length === 1) {
           const [selectedItem] = selection;

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,7 +194,7 @@ export type GoogleChartWrapper = {
     setAction: (ChartAction: GoogleChartAction) => void;
     getImageURI: () => void;
     clearChart: () => void; // Clears the chart, and releases all of its allocated resources.
-  }; // ref to chart
+  } | null; // ref to chart
   getContainerId: () => string;
   getQuery: () => string;
   getRefreshInterval: () => number;


### PR DESCRIPTION
According to [docs](https://developers.google.com/chart/interactive/docs/reference#methods_2), `.getChart()` returns null if it is called before `.draw()`

