### PR TITLE
updates broken homepage link to new homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "staticpath": "demo/dist/"
   },
   "author": "Rakan Nimer",
-  "homepage": "https://rakannimer.github.io/react-google-charts/",
+  "homepage": "https://react-google-charts.com",
   "license": "MIT",
   "repository": "https://github.com/RakanNimer/react-google-charts",
   "keywords": [


### PR DESCRIPTION
I noticed this was broken when I clicked "Homepage" on NPM a few days ago https://www.npmjs.com/package/react-google-charts