### PR TITLE
add null as cell type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -303,7 +303,8 @@ export type GoogleDataTableCell =
   | string
   | number
   | boolean
-  | Date;
+  | Date
+  | null;
 
 export type GoogleDataTableRow = GoogleDataTableCell[];
 


### PR DESCRIPTION
Null is a valid cell type to pass into google charts, per the docs here: https://developers.google.com/chart/interactive/docs/gallery/areachart#stacking-areas