### PR TITLE
Introduce new prop `onLoad`

### DIFF
--- a/src/ReactGoogleCharts.tsx
+++ b/src/ReactGoogleCharts.tsx
@@ -4,7 +4,7 @@ import {
   GoogleViz,
   ReactGoogleChartProps,
   ReactGoogleChartState,
-  ReactGoogleChartPropsWithDefaults
+  ReactGoogleChartPropsWithDefaults,
 } from "./types";
 import { chartDefaultProps } from "./default-props";
 import { GoogleChartLoader } from "./components/GoogleChartLoader";
@@ -15,12 +15,11 @@ export class Chart extends React.Component<
   ReactGoogleChartProps,
   ReactGoogleChartState
 > {
-
   _isMounted = false;
 
   state = {
     loadingStatus: "loading" as ReactGoogleChartState["loadingStatus"],
-    google: null as ReactGoogleChartState["google"]
+    google: null as ReactGoogleChartState["google"],
   };
 
   static defaultProps = chartDefaultProps;
@@ -32,13 +31,14 @@ export class Chart extends React.Component<
       chartVersion,
       mapsApiKey,
       loader,
-      errorElement
+      onLoad,
+      errorElement,
     } = this.props;
     return (
       <ContextProvider value={this.props as ReactGoogleChartPropsWithDefaults}>
         {this.state.loadingStatus === "ready" && this.state.google !== null ? (
           <GoogleChart
-            {...this.props as ReactGoogleChartPropsWithDefaults}
+            {...(this.props as ReactGoogleChartPropsWithDefaults)}
             google={this.state.google}
           />
         ) : this.state.loadingStatus === "errored" && errorElement ? (
@@ -49,6 +49,7 @@ export class Chart extends React.Component<
         <GoogleChartLoader
           {...{ chartLanguage, chartPackages, chartVersion, mapsApiKey }}
           onLoad={this.onLoad}
+          onLoadCallback={onLoad}
           onError={this.onError}
         />
       </ContextProvider>
@@ -69,9 +70,11 @@ export class Chart extends React.Component<
     } else {
       // IE11: window.google is not fully set, we have to wait
       const id = setInterval(() => {
-        const google = (window as Window & {
-          google?: GoogleViz;
-        }).google;
+        const google = (
+          window as Window & {
+            google?: GoogleViz;
+          }
+        ).google;
 
         if (this._isMounted) {
           if (google && this.isFullyLoaded(google)) {
@@ -81,7 +84,6 @@ export class Chart extends React.Component<
         } else {
           clearInterval(id);
         }
-
       }, 1000);
     }
   };
@@ -89,13 +91,13 @@ export class Chart extends React.Component<
   onSuccess = (google: GoogleViz) => {
     this.setState({
       loadingStatus: "ready",
-      google
+      google,
     });
   };
 
   onError = () => {
     this.setState({
-      loadingStatus: "errored"
+      loadingStatus: "errored",
     });
   };
 

--- a/src/components/GoogleChartLoader.tsx
+++ b/src/components/GoogleChartLoader.tsx
@@ -9,6 +9,7 @@ export interface Props {
   chartLanguage: ReactGoogleChartProps["chartLanguage"];
   mapsApiKey: ReactGoogleChartProps["mapsApiKey"];
   onLoad: (google: GoogleViz) => void;
+  onLoadCallback?: (google: GoogleViz) => void;
   onError: () => void;
 }
 
@@ -21,14 +22,16 @@ export class GoogleChartLoader extends React.Component<Props> {
       chartPackages: packages,
       chartLanguage: language,
       mapsApiKey,
-      onLoad
+      onLoad,
+      onLoadCallback,
     } = this.props;
     windowGoogleCharts.charts.load(version || "current", {
       packages: packages || ["corechart", "controls"],
       language: language || "en",
-      mapsApiKey
+      mapsApiKey,
     });
     windowGoogleCharts.charts.setOnLoadCallback(() => {
+      onLoadCallback && onLoadCallback(windowGoogleCharts);
       onLoad(windowGoogleCharts);
     });
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,7 +278,7 @@ export enum GoogleDataTableColumnRoleType {
   scope = "scope",
   style = "style",
   tooltip = "tooltip",
-  domain = "domain"
+  domain = "domain",
 }
 
 export type GoogleDataTableColumn =
@@ -349,9 +349,10 @@ export type GoogleDataTable = {
   getColumnPattern: (columnIndex: number) => string;
   getColumnProperties: (columnIndex: number) => {};
   getColumnProperty: (columnIndex: number, name: string) => any;
-  getColumnRange: (
-    columnIndex: number
-  ) => { min: number | null; max: number | null };
+  getColumnRange: (columnIndex: number) => {
+    min: number | null;
+    max: number | null;
+  };
   getColumnRole: (columnIndex: number) => GoogleDataTableColumnRoleType;
   getColumnType: (columnIndex: number) => GoogleDataTableColumnType;
   getDistinctValues: (columnIndex: number) => any[];
@@ -539,6 +540,7 @@ export type ReactGoogleChartProps = {
   graph_id?: string;
   legendToggle?: boolean;
   legend_toggle?: boolean;
+  onLoad?: (google: GoogleViz) => void;
   getChartWrapper?: (
     chartWrapper: GoogleChartWrapper,
     google: GoogleViz
@@ -588,12 +590,12 @@ export type GoogleChartDashboard = {
 export type ReactGoogleChartDashboardRender = ({
   renderControl,
   renderChart,
-  renderToolbar
+  renderToolbar,
 }: {
   renderControl: (
     filter: ({
       control,
-      controlProp
+      controlProp,
     }: {
       control: GoogleChartControl;
       controlProp: GoogleChartControlProp;


### PR DESCRIPTION
Hi. I need to load custom map source for Geo Chart (call `google.visualization.GeoChart.setMapSource()`). This must be done before the first `draw()` in order to load my custom maps, not default.

I found tree ways to do that.
1. `windowGoogleCharts.charts.setOnLoadCallback` => `this.onLoad` => `this.onSuccess` => `this.props.onLoad`
2. `windowGoogleCharts.charts.setOnLoadCallback` => `this.props.onLoad`
3. `componentDidMount` (table) => `this.props.onLoad`

The 1st - in fact is not working for my case because my callback is called after first `draw()` in `componentDidMount` (table).
The 3rd is working, but it looks ugly, so I think the second is the best option. It looks clean and it is guaranteed to be called before first `draw()`.