### PR TITLE
docs: add link to tutorial and cube

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ import { Chart } from "react-google-charts";
   legendToggle
 />
 ```
-You can also check this [step-by-step tutorial](https://cube.dev/blog/react-google-charts-dashboard/?ref=eco-react-google-charts) that will walk you through the creation of a full-fledged dashboard with this library.
 
 ## Docs
 
 - [Quick Walkthrough](https://react-google-charts.com/docs/quick-walkthrough)
 - [Components](https://react-google-charts.com/components)
 - [Examples](https://react-google-charts.com/examples)
+
+You can also check this [step-by-step tutorial](https://cube.dev/blog/react-google-charts-dashboard/?ref=eco-react-google-charts) that will walk you through the creation of a full-fledged dashboard with this library.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ import { Chart } from "react-google-charts";
   legendToggle
 />
 ```
+You can also check this [step-by-step tutorial](https://cube.dev/blog/react-google-charts-dashboard/?ref=eco-react-google-charts) that will walk you through the creation of a full-fledged dashboard with this library.
 
-# Docs
+## Docs
 
 - [Quick Walkthrough](https://react-google-charts.com/docs/quick-walkthrough)
 - [Components](https://react-google-charts.com/components)

--- a/website/docs/docs.js
+++ b/website/docs/docs.js
@@ -1,3 +1,4 @@
 exports.docs = [
   { title: "Quick Walkthrough", slug: "/docs/quick-walkthrough" },
+  { title: "Sponsor", slug: "/docs/sponsor" },
 ];

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -48,6 +48,8 @@ import { Chart } from "react-google-charts";
 
 Please see [live examples](/examples).
 
+You can also check this [step-by-step tutorial](https://cube.dev/blog/react-google-charts-dashboard/?ref=eco-react-google-charts) that will walk you through the creation of a full-fledged dashboard with this library.
+
 ## Getting Help
 
 Need help? Ask your question on [Slack](https://slack.cube.dev/?ref=eco-react-google-charts) or [Stack Overflow](https://stackoverflow.com/questions/tagged/react-google-charts).

--- a/website/docs/sponsor.md
+++ b/website/docs/sponsor.md
@@ -1,0 +1,10 @@
+---
+slug: /docs/sponsor
+description: supported and maintained by cube
+---
+
+# Sponsor
+
+This library is supported by the creators of [Cube](https://cube.dev/?ref=eco-react-google-charts), the headless business intelligence for building powerful, fast, and consistent data applications.
+
+Need an API to fetch data? Consider Cube, it [works great](https://cube.dev/blog/react-google-charts-dashboard/?ref=eco-react-google-charts) with React Google Charts.

--- a/website/docs/sponsor.md
+++ b/website/docs/sponsor.md
@@ -5,6 +5,6 @@ description: supported and maintained by cube
 
 # Sponsor
 
-This library is supported by the creators of [Cube](https://cube.dev/?ref=eco-react-google-charts), the headless business intelligence for building powerful, fast, and consistent data applications.
+This library is maintained by the creators of [Cube](https://cube.dev/?ref=eco-react-google-charts), the headless business intelligence for building powerful, fast, and consistent data applications.
 
 Need an API to fetch data? Consider Cube, it [works great](https://cube.dev/blog/react-google-charts-dashboard/?ref=eco-react-google-charts) with React Google Charts.


### PR DESCRIPTION
Hey @rakannimer 👋

@dangreen and I have created a [tutorial](https://cube.dev/blog/react-google-charts-dashboard/) that shows how to use this library to build a full-fledged dashboard. So, I went ahead and added links to this tutorial to the Examples sections.

Also, I've added the Sponsor page as we previously discussed. Are you okay to merge this?