### PR TITLE
Fix getImageURI type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -189,7 +189,7 @@ export type GoogleChartWrapper = {
     removeAction: (actionID: string) => void;
     getSelection: () => { row?: any; column?: any }[];
     setAction: (ChartAction: GoogleChartAction) => void;
-    getImageURI: () => void;
+    getImageURI: () => string | undefined;
     clearChart: () => void; // Clears the chart, and releases all of its allocated resources.
   }; // ref to chart
   getContainerId: () => string;


### PR DESCRIPTION
- Use the correct type for `getImageUri`
<img width="1447" alt="image" src="https://github.com/rakannimer/react-google-charts/assets/6893512/dd6950fa-3dec-4ef7-8e39-aa5d87823bd8">
