### PR TITLE
Fixed the way event listeners are removed

### DIFF
--- a/packages/react-google-charts/src/components/GoogleChart.tsx
+++ b/packages/react-google-charts/src/components/GoogleChart.tsx
@@ -89,7 +89,7 @@ export const GoogleChart: React.FC<Props> = (props) => {
     });
     setGoogleChartWrapper(chartWrapper);
     setGoogleChartDashboard(chartDashboard);
-    setChartControls(chartControls);
+    setChartControls(chartControls?.map(({ control }) => control) ?? null);
     onLoad?.(google, {
       google,
       chartWrapper,

--- a/packages/react-google-charts/src/components/GoogleChart.tsx
+++ b/packages/react-google-charts/src/components/GoogleChart.tsx
@@ -22,7 +22,7 @@ export const GoogleChart: React.FC<Props> = (props) => {
   const [googleChartDashboard, setGoogleChartDashboard] =
     React.useState<GoogleChartDashboard | null>(null);
 
-  const { addControls, setChartControls, renderControl } = useChartControls({
+  const { addControls, renderControl } = useChartControls({
     ...props,
     chartDashboard: googleChartDashboard,
     chartWrapper: googleChartWrapper,
@@ -82,14 +82,9 @@ export const GoogleChart: React.FC<Props> = (props) => {
       });
     }
     // Create and add controls to the chart / dashboard
-    const chartControls = addControls({
-      ...props,
-      chartDashboard,
-      chartWrapper,
-    });
+    addControls({ ...props, chartDashboard, chartWrapper });
     setGoogleChartWrapper(chartWrapper);
     setGoogleChartDashboard(chartDashboard);
-    setChartControls(chartControls?.map(({ control }) => control) ?? null);
     onLoad?.(google, {
       google,
       chartWrapper,

--- a/packages/react-google-charts/src/hooks/internal/useGoogleChartControls.tsx
+++ b/packages/react-google-charts/src/hooks/internal/useGoogleChartControls.tsx
@@ -83,8 +83,10 @@ export const useChartControls = (props: UseChartControlsParams) => {
   };
 
   return {
-    addControls: GoogleChartControlsInternal.addControls,
-    setChartControls,
+    addControls: (props: UseChartControlsParams) => {
+      const controls = GoogleChartControlsInternal.addControls(props);
+      setChartControls(controls?.map((control) => control.control) ?? null);
+    },
     renderControl,
   };
 };

--- a/packages/react-google-charts/src/hooks/internal/useGoogleChartControls.tsx
+++ b/packages/react-google-charts/src/hooks/internal/useGoogleChartControls.tsx
@@ -12,6 +12,45 @@ import {
 } from "../../components/GoogleChartControls";
 import { GoogleChartControlsInternal } from "../../utils/GoogleChartControlsInternal";
 
+const useCreateChartControls = (
+  controls: ReactGoogleChartProps["controls"],
+) => {
+  const [chartControls, setChartControls] = React.useState<
+    GoogleChartControl[] | null
+  >(null);
+
+  const controlAndProp = React.useMemo(() => {
+    if (!chartControls || !controls) return null;
+
+    return controls
+      .map((controlProp, i): GoogleChartControlAndProp | undefined => {
+        const control: GoogleChartControl | undefined = chartControls[i];
+        return control ? { controlProp, control } : undefined;
+      })
+      .flatMap((controlAndProp) => (controlAndProp ? [controlAndProp] : []));
+  }, [chartControls, controls]);
+
+  return [controlAndProp, setChartControls] as const;
+};
+
+const useListenToControlEvents = (
+  chartControls: GoogleChartControlAndProp[],
+  props: UseChartControlsParams,
+) => {
+  React.useEffect(() => {
+    const listeners = GoogleChartControlsInternal.listenToControlEvents(
+      chartControls ?? [],
+      props,
+    );
+
+    return () => {
+      listeners.forEach((listener) => {
+        props.google.visualization.events.removeListener(listener);
+      });
+    };
+  }, [chartControls, props]);
+};
+
 export type Props = ReactGoogleChartProps & {
   google: GoogleViz;
 };
@@ -22,10 +61,11 @@ export type GoogleChartControlAndProp = {
 };
 
 export const useChartControls = (props: UseChartControlsParams) => {
-  const [chartControls, setChartControls] = React.useState<
-    | { control: GoogleChartControl; controlProp: GoogleChartControlProp }[]
-    | null
-  >(null);
+  const [chartControls, setChartControls] = useCreateChartControls(
+    props.controls,
+  );
+
+  useListenToControlEvents(chartControls ?? [], props);
 
   /**
    * Render the container divs for the controls
@@ -44,7 +84,6 @@ export const useChartControls = (props: UseChartControlsParams) => {
 
   return {
     addControls: GoogleChartControlsInternal.addControls,
-    chartControls,
     setChartControls,
     renderControl,
   };

--- a/packages/react-google-charts/src/types.ts
+++ b/packages/react-google-charts/src/types.ts
@@ -9,6 +9,7 @@ export type GoogleViz = {
   charts: GoogleChartLoader;
   visualization: {
     ChartWrapper: GoogleChartWrapper;
+    ControlWrapper: GoogleChartControl;
     ChartEditor: GoogleChartEditor;
     DataTable: GoogleDataTable;
     events: GoogleVizEvents;
@@ -216,6 +217,10 @@ export type GoogleChartWrapper = {
   setOptions: (options_obj: Partial<ChartWrapperOptions["options"]>) => void; //
 };
 
+export type GoogleVizEventListener = {
+  key: Record<string, unknown>;
+};
+
 export type GoogleVizEventName =
   | "ready"
   | "error"
@@ -231,12 +236,8 @@ export type GoogleVizEvents = {
     chartWrapper: GoogleChartWrapper | GoogleChartControl | GoogleChartEditor,
     name: GoogleVizEventName,
     onEvent: (chartWrapper: GoogleChartWrapper) => any,
-  ) => any;
-  removeListener: (
-    chartWrapper: GoogleChartWrapper | GoogleChartControl,
-    name: GoogleVizEventName,
-    callback: Function,
-  ) => any;
+  ) => GoogleVizEventListener;
+  removeListener: (eventListener: GoogleVizEventListener) => any;
   removeAllListeners: (chartWrapper: GoogleChartWrapper) => any;
 };
 
@@ -641,6 +642,7 @@ export type ReactGoogleChartDashboardRender = ({
 }) => any;
 export type GoogleChartControlOptions = any;
 export type GoogleChartControl = {
+  new (chartWrapperOptions: GoogleChartControlOptions): GoogleChartControl;
   getContainerId: () => string;
   getOptions: () => GoogleChartControlOptions;
   getState: () => any;

--- a/packages/react-google-charts/src/utils/GoogleChartControlsInternal.ts
+++ b/packages/react-google-charts/src/utils/GoogleChartControlsInternal.ts
@@ -39,27 +39,22 @@ export class GoogleChartControlsInternal {
   };
 
   /**
-   * After the controls are initialized, listen to the control events (ready, statechange, error) specified in the controlEvents prop
+   * listen to the control events (ready, statechange, error) specified in the controlEvents prop
    */
-  private static listenToControlEvents = (
+  public static listenToControlEvents = (
     googleChartControls: GoogleChartControlAndProp[],
     props: UseChartControlsParams,
   ) => {
     const { google } = props;
-    for (let chartControl of googleChartControls) {
+    return googleChartControls.flatMap((chartControl) => {
       const { control, controlProp } = chartControl;
       const { controlEvents = [] } = controlProp;
-      for (let event of controlEvents) {
+      return controlEvents.map((event) => {
         const { callback, eventName } = event;
-        google.visualization.events.removeListener(
+        return google.visualization.events.addListener(
           control,
           eventName,
-          callback,
-        );
-        google.visualization.events.addListener(
-          control,
-          eventName,
-          (...args: any[]) => {
+          (...args) => {
             callback({
               chartWrapper: null,
               controlWrapper: control,
@@ -69,8 +64,8 @@ export class GoogleChartControlsInternal {
             });
           },
         );
-      }
-    }
+      });
+    });
   };
 
   /**
@@ -125,7 +120,6 @@ export class GoogleChartControlsInternal {
       googleChartControls.map(({ control }) => control),
       chartWrapper,
     );
-    this.listenToControlEvents(googleChartControls, props);
     this.initializeControls(googleChartControls);
     return googleChartControls;
   };

--- a/packages/react-google-charts/src/utils/GoogleChartInternal.ts
+++ b/packages/react-google-charts/src/utils/GoogleChartInternal.ts
@@ -59,7 +59,7 @@ export class GoogleChartInternal {
       console.error("googleChartWrapper is not defined");
       return;
     }
-    google.visualization.events.addListener(
+    return google.visualization.events.addListener(
       googleChartWrapper,
       "select",
       () => {

--- a/packages/react-google-charts/test/EventListening.spec.tsx
+++ b/packages/react-google-charts/test/EventListening.spec.tsx
@@ -1,0 +1,356 @@
+import React from "react";
+import { render, cleanup, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  Chart,
+  GoogleChartControl,
+  GoogleChartWrapper,
+  GoogleViz,
+  ReactGoogleChartProps,
+} from "../src";
+
+const fireSelectEvent = ({
+  google,
+  chartWrapper,
+}: {
+  google: GoogleViz;
+  chartWrapper: GoogleChartWrapper;
+}) => {
+  jest.spyOn(chartWrapper, "getChart").mockImplementation(() => ({
+    removeAction: () => {},
+    getSelection: () => [{ row: null, column: 1 }],
+    setAction: () => {},
+    getImageURI: () => {},
+    clearChart: () => {},
+  }));
+
+  (google.visualization.events as any).trigger(chartWrapper, "select");
+};
+
+const fireStatechangeEvent = ({
+  google,
+  controlWrapper,
+}: {
+  google: GoogleViz;
+  controlWrapper: GoogleChartControl;
+}) => {
+  (google.visualization.events as any).trigger(controlWrapper, "statechange");
+};
+
+describe("Event Listening", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("toggles chart visibility on select event", async () => {
+    let chartInstance!: { google: GoogleViz; chartWrapper: GoogleChartWrapper };
+
+    const { container } = render(
+      <Chart
+        chartType="BarChart"
+        data={[
+          ["Year", "Value"],
+          ["2024", 1000],
+        ]}
+        legendToggle
+        chartEvents={[
+          {
+            eventName: "ready",
+            callback: ({ google, chartWrapper }) => {
+              chartInstance = { google, chartWrapper: chartWrapper! };
+            },
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(chartInstance).toBeTruthy(), {
+      timeout: 5_000,
+    });
+    await waitFor(() =>
+      expect(container.querySelector('rect[fill="#3366cc"]')).toBeVisible(),
+    );
+
+    act(() => fireSelectEvent(chartInstance));
+    await waitFor(() =>
+      expect(
+        container.querySelector('rect[fill="#3366cc"]'),
+      ).not.toBeInTheDocument(),
+    );
+
+    act(() => fireSelectEvent(chartInstance));
+    await waitFor(() =>
+      expect(container.querySelector('rect[fill="#3366cc"]')).toBeVisible(),
+    );
+  });
+
+  it("should call `chartEvents` callback", async () => {
+    const eventCallback = jest.fn();
+    let chartInstance!: { google: GoogleViz; chartWrapper: GoogleChartWrapper };
+
+    const props: ReactGoogleChartProps = {
+      chartType: "BarChart",
+      data: [
+        ["Year", "Value"],
+        ["2024", 1000],
+      ],
+      chartEvents: [
+        {
+          eventName: "ready",
+          callback: ({ google, chartWrapper }) => {
+            chartInstance = { google, chartWrapper: chartWrapper! };
+            eventCallback("first rendering");
+          },
+        },
+      ],
+      rootProps: { "data-testid": "1" },
+    };
+    const { getByTestId, rerender } = render(<Chart {...props} />);
+
+    await waitFor(() => expect(getByTestId("1")), { timeout: 5_000 });
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("first rendering"),
+    );
+
+    eventCallback.mockClear();
+    rerender(
+      <Chart
+        {...props}
+        chartEvents={[
+          {
+            eventName: "select",
+            callback: () => eventCallback("second rendering"),
+          },
+        ]}
+      />,
+    );
+
+    act(() => fireSelectEvent(chartInstance));
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("second rendering"),
+    );
+  });
+
+  it("should call `controlEvents` callback", async () => {
+    const eventCallback = jest.fn();
+    let chartInstance!: {
+      google: GoogleViz;
+      controlWrapper: GoogleChartControl;
+    };
+
+    const props: ReactGoogleChartProps = {
+      chartType: "BarChart",
+      data: [
+        ["Year", "Value"],
+        ["2024", 1000],
+      ],
+      controls: [
+        {
+          controlType: "StringFilter",
+          options: { filterColumnIndex: 1 },
+          controlEvents: [
+            {
+              eventName: "ready",
+              callback: ({ google, controlWrapper }) => {
+                chartInstance = { google, controlWrapper: controlWrapper! };
+                eventCallback("first rendering");
+              },
+            },
+          ],
+        },
+      ],
+      rootProps: { "data-testid": "1" },
+    };
+    const { getByTestId, rerender, container } = render(<Chart {...props} />);
+
+    await waitFor(() => expect(getByTestId("1")), { timeout: 5_000 });
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("first rendering"),
+    );
+
+    eventCallback.mockClear();
+    rerender(
+      <Chart
+        {...props}
+        controls={[
+          {
+            controlType: "StringFilter",
+            options: { filterColumnIndex: 1 },
+            controlEvents: [
+              {
+                eventName: "statechange",
+                callback: () => eventCallback("second rendering of alpha"),
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    act(() => fireStatechangeEvent(chartInstance));
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("second rendering of alpha"),
+    );
+  });
+
+  it("should call `chartEvents` callback for each individual component", async () => {
+    const eventCallback = jest.fn();
+    let chartInstance!: { google: GoogleViz; chartWrapper: GoogleChartWrapper };
+
+    const alphaChartProps: ReactGoogleChartProps = {
+      chartType: "BarChart",
+      data: [
+        ["Year", "Value"],
+        ["2024", 1000],
+      ],
+      chartEvents: [
+        {
+          eventName: "ready",
+          callback: ({ google, chartWrapper }) => {
+            chartInstance = { google, chartWrapper: chartWrapper! };
+            eventCallback("first rendering of alpha");
+          },
+        },
+      ],
+      rootProps: { "data-testid": "alphaChart" },
+    };
+
+    const betaChartProps: ReactGoogleChartProps = {
+      ...alphaChartProps,
+      chartEvents: [
+        {
+          eventName: "ready",
+          callback: () => eventCallback("first rendering of beta"),
+        },
+      ],
+      rootProps: { "data-testid": "betaChart" },
+    };
+
+    const { getByTestId, rerender } = render(
+      <>
+        <Chart {...alphaChartProps} />
+        <Chart {...betaChartProps} />
+      </>,
+    );
+
+    await waitFor(() => expect(getByTestId("alphaChart")), { timeout: 5_000 });
+    await waitFor(() => expect(getByTestId("betaChart")), { timeout: 5_000 });
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("first rendering of alpha"),
+    );
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("first rendering of beta"),
+    );
+
+    eventCallback.mockClear();
+    rerender(
+      <>
+        <Chart
+          {...alphaChartProps}
+          chartEvents={[
+            {
+              eventName: "select",
+              callback: () => eventCallback("second rendering of alpha"),
+            },
+          ]}
+        />
+      </>,
+    );
+
+    act(() => fireSelectEvent(chartInstance));
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("second rendering of alpha"),
+    );
+  });
+
+  it("should call `controlEvents` callback for each individual component", async () => {
+    const eventCallback = jest.fn();
+    let chartInstance!: {
+      google: GoogleViz;
+      controlWrapper: GoogleChartControl;
+    };
+
+    const alphaChartProps: ReactGoogleChartProps = {
+      chartType: "BarChart",
+      data: [
+        ["Year", "Value"],
+        ["2024", 1000],
+      ],
+      controls: [
+        {
+          controlType: "StringFilter",
+          options: { filterColumnIndex: 1 },
+          controlEvents: [
+            {
+              eventName: "ready",
+              callback: ({ google, controlWrapper }) => {
+                chartInstance = { google, controlWrapper: controlWrapper! };
+                eventCallback("first rendering of alpha");
+              },
+            },
+          ],
+        },
+      ],
+      rootProps: { "data-testid": "alphaChart" },
+    };
+
+    const betaChartProps: ReactGoogleChartProps = {
+      ...alphaChartProps,
+      controls: [
+        {
+          controlType: "StringFilter",
+          options: { filterColumnIndex: 1 },
+          controlEvents: [
+            {
+              eventName: "ready",
+              callback: () => eventCallback("second rendering of alpha"),
+            },
+          ],
+        },
+      ],
+      rootProps: { "data-testid": "betaChart" },
+    };
+
+    const { getByTestId, rerender } = render(
+      <>
+        <Chart {...alphaChartProps} />
+        <Chart {...betaChartProps} />
+      </>,
+    );
+
+    await waitFor(() => expect(getByTestId("alphaChart")), { timeout: 5_000 });
+    await waitFor(() => expect(getByTestId("betaChart")), { timeout: 5_000 });
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("first rendering of alpha"),
+    );
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("second rendering of alpha"),
+    );
+
+    eventCallback.mockReset();
+    rerender(
+      <>
+        <Chart
+          {...alphaChartProps}
+          controls={[
+            {
+              controlType: "StringFilter",
+              options: { filterColumnIndex: 1 },
+              controlEvents: [
+                {
+                  eventName: "statechange",
+                  callback: () => eventCallback("second rendering of alpha"),
+                },
+              ],
+            },
+          ]}
+        />
+      </>,
+    );
+
+    act(() => fireStatechangeEvent(chartInstance));
+    await waitFor(() =>
+      expect(eventCallback).toHaveBeenCalledWith("second rendering of alpha"),
+    );
+  });
+});


### PR DESCRIPTION
relate: #716 

Fixed a problem in strict mode where removing an event listener using removeAllListeners would remove all added event listeners.
Also fixed a problem where event listeners would not be re-registered when a new callback was passed due to re-rendering. [^1]

[^1]: #709 Probably, this changes prevented listeners from re-registering when the props was changed.
