### PR TITLE
fix(typings): fix setValue value param should accept same types as getValue

### DIFF
--- a/packages/react-google-charts/src/types.ts
+++ b/packages/react-google-charts/src/types.ts
@@ -419,7 +419,7 @@ export type GoogleDataTable = {
   setRowProperty: (rowIndex: number, name: string, value: any) => void;
   setRowProperties: (rowIndex: number, properties: {} | null) => void;
   setTableProperties: (properties: {} | null) => void;
-  setValue: (rowIndex: number, columnIndex: number, value: string) => void;
+  setValue: (rowIndex: number, columnIndex: number, value: boolean | string | number | Date | number[] | null) => void;
   sort: (sortColumns: GoogleDataTableSortColumns) => void;
   toJSON: () => string; // GoogleDataTableJS
 };


### PR DESCRIPTION
As doc says https://developers.google.com/chart/interactive/docs/reference#DataTable_setValue

Thanks!