### PR TITLE
fix(docs): material bar chart's stack option

### DIFF
--- a/apps/docs/docs/examples/bar-chart-material.mdx
+++ b/apps/docs/docs/examples/bar-chart-material.mdx
@@ -168,11 +168,11 @@ const options = {
 
 ### Stacked Bar Chart
 
-To stack the bars, set the `isStacked` option to `true`:
+To stack the bars, set the `stacked` option to `true`:
 
 ```jsx
 const options = {
-  isStacked: true,
+  stacked: true,
   chart: {
     title: "Company Performance",
     subtitle: "Sales and Expenses over the Years",


### PR DESCRIPTION
Change option `isStacked` to `stacked` according to [this](https://github.com/google/google-visualization-issues/issues/2143#issuecomment-230798488).