### PR TITLE
 fix: set loading/success when erroring in `useLoadScript`

### DIFF
--- a/packages/react-google-charts/src/hooks/useLoadScript.ts
+++ b/packages/react-google-charts/src/hooks/useLoadScript.ts
@@ -12,14 +12,20 @@ export function useLoadScript(src: string) {
   const [isSuccess, setIsSuccess] = useState(false);
   const onLoad = () => {
     setIsLoading(false);
+    setError(null);
     setIsSuccess(true);
+  };
+  const onError = (error: Error | null) => {
+    setError(error);
+    setIsLoading(false);
+    setIsSuccess(false);
   };
   useEffect(() => {
     if (!document) {
       const error = new Error(
         `[ScriptLoadingError] document not defined when attempting to load ${src}`,
       );
-      setError(error);
+      onError(error);
       return;
     }
 
@@ -55,7 +61,7 @@ export function useLoadScript(src: string) {
       const error = new Error(
         `[ScriptLoadingError] Failed to load script: ${src}`,
       );
-      setError(error);
+      onError(error);
     });
 
     // Add to DOM if not yet added.

--- a/packages/react-google-charts/test/Chart.spec.tsx
+++ b/packages/react-google-charts/test/Chart.spec.tsx
@@ -15,6 +15,31 @@ describe("<Chart />", () => {
     expect(getByText("Loading Chart")).toBeVisible();
   });
 
+  it("should render errorElement", async () => {
+    const { getByText } = render(
+      <Chart
+        chartType="AreaChart"
+        chartLoaderScriptUrl="http://0.0.0.0/invalid-errorElement.js"
+        errorElement={<div>Don't Panic</div>} />,
+    );
+
+    await waitFor(() => expect(getByText("Don't Panic")).toBeVisible());
+  });
+
+  it("should render loader then errorElement", async () => {
+    const { getByText } = render(
+      <Chart
+        chartType="AreaChart"
+        chartLoaderScriptUrl="http://0.0.0.0/invalid-loader-errorElement.js"
+        loader={<div>Loading Chart</div>}
+        errorElement={<div>Don't Panic</div>} />,
+    );
+
+    expect(getByText("Loading Chart")).toBeVisible();
+
+    await waitFor(() => expect(getByText("Don't Panic")).toBeVisible());
+  });
+
   it("should draw chart", async () => {
     const { getByTestId } = render(
       <Chart

--- a/packages/react-google-charts/test/Chart.spec.tsx
+++ b/packages/react-google-charts/test/Chart.spec.tsx
@@ -16,18 +16,19 @@ describe("<Chart />", () => {
   });
 
   it("should render errorElement", async () => {
-    const { getByText } = render(
+    const { findByText } = render(
       <Chart
         chartType="AreaChart"
         chartLoaderScriptUrl="http://0.0.0.0/invalid-errorElement.js"
         errorElement={<div>Don't Panic</div>} />,
     );
 
-    await waitFor(() => expect(getByText("Don't Panic")).toBeVisible());
+    expect(await findByText("Don't Panic")).toBeVisible();
+
   });
 
   it("should render loader then errorElement", async () => {
-    const { getByText } = render(
+    const { getByText, queryByText, findByText } = render(
       <Chart
         chartType="AreaChart"
         chartLoaderScriptUrl="http://0.0.0.0/invalid-loader-errorElement.js"
@@ -36,8 +37,10 @@ describe("<Chart />", () => {
     );
 
     expect(getByText("Loading Chart")).toBeVisible();
+    expect(queryByText("Don't Panic")).toBeNull();
 
-    await waitFor(() => expect(getByText("Don't Panic")).toBeVisible());
+    expect(await findByText("Don't Panic")).toBeVisible();
+    expect(queryByText("Loading Chart")).toBeNull();
   });
 
   it("should draw chart", async () => {


### PR DESCRIPTION
When trying to use `errorElement` to display an error message when the Google Charts API doesn't load, I found that `isLoading` never goes to false, which means that the below only renders `props.loader` and can never render `props.errorElement`:

https://github.com/rakannimer/react-google-charts/blob/27d1ba8f55161dbb8b54fedc58d32df3597e9c1f/packages/react-google-charts/src/Chart.tsx#L11-L18

This PR solves the issue by calling `setIsLoading(false);` after `setError(error);`, and centralises this logic into a `onError(error)` handler, which consistently sets all three states for loading, error and success. Equally, `onLoad` has been adjusted slightly to clear an existing `error` if set -- such as when retrying or with a changed `src`.

Tests have been added to ensure that `errorElement` renders; these would have failed without the changes in this PR.